### PR TITLE
[VIT-2429] Workaround incorrectly imported dateOfBirthComponents()

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/StarryInternet/CombineCoreBluetooth.git",
         "state": {
           "branch": null,
-          "revision": "52ecaa2e7a94f9aff9c823532993cd266fd74c6a",
-          "version": "0.3.1"
+          "revision": "05df53532ba6eee30df83a20dd22c447bc223f8a",
+          "version": "0.4.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/WeTransfer/Mocker.git",
         "state": {
           "branch": null,
-          "revision": "e7165fb0378193c6784f1d46a9ab2b6184c384fa",
-          "version": "2.7.0"
+          "revision": "5d86f27a8f80d4ba388bc1a379a3c2289a1f3d18",
+          "version": "2.6.0"
         }
       }
     ]

--- a/Sources/VitalHealthKit/Extensions/Date.swift
+++ b/Sources/VitalHealthKit/Extensions/Date.swift
@@ -1,7 +1,8 @@
 import Foundation
 
+/// UTC Gregorian calendar for standard statistical queries.
 let vitalCalendar: Calendar = {
-  var calendar = Calendar.autoupdatingCurrent
+  var calendar = Calendar(identifier: .gregorian)
   calendar.timeZone = TimeZone(abbreviation: "UTC")!
   return calendar
 }()

--- a/Sources/VitalHealthKit/Extensions/HKHealthStore.swift
+++ b/Sources/VitalHealthKit/Extensions/HKHealthStore.swift
@@ -1,0 +1,14 @@
+import Foundation
+import HealthKit
+
+extension HKHealthStore {
+  internal func patched_dateOfBirthComponents() throws -> DateComponents? {
+    do {
+      return try dateOfBirthComponents()
+    } catch let error as NSError {
+      guard error.code == 0 && error.domain == "Foundation._GenericObjCError"
+        else { throw error }
+      return nil
+    }
+  }
+}

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -297,11 +297,7 @@ func handleProfile(
   let biologicalSex = ProfilePatch.BiologicalSex(healthKitSex: sex)
 
   var components = try healthKitStore.patched_dateOfBirthComponents()
-  components?.timeZone = TimeZone(secondsFromGMT: 0)
-  // HealthKit promises that the returned components respect Grogorian calendar.
-  components?.calendar = Calendar(identifier: .gregorian)
-
-  let dateOfBirth = components?.date
+  let dateOfBirth = vitalCalendar.date(from: components)
 
   let payload: [QuantitySample] = try await querySample(
     healthKitStore: healthKitStore,

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -295,12 +295,14 @@ func handleProfile(
   
   let sex = try healthKitStore.biologicalSex().biologicalSex
   let biologicalSex = ProfilePatch.BiologicalSex(healthKitSex: sex)
-  
-  var components = try healthKitStore.dateOfBirthComponents()
-  components.timeZone = TimeZone(secondsFromGMT: 0)
-  
-  let dateOfBirth = components.date!
-  
+
+  var components = try healthKitStore.patched_dateOfBirthComponents()
+  components?.timeZone = TimeZone(secondsFromGMT: 0)
+  // HealthKit promises that the returned components respect Grogorian calendar.
+  components?.calendar = Calendar(identifier: .gregorian)
+
+  let dateOfBirth = components?.date
+
   let payload: [QuantitySample] = try await querySample(
     healthKitStore: healthKitStore,
     type: .quantityType(forIdentifier: .height)!,

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -296,8 +296,8 @@ func handleProfile(
   let sex = try healthKitStore.biologicalSex().biologicalSex
   let biologicalSex = ProfilePatch.BiologicalSex(healthKitSex: sex)
 
-  var components = try healthKitStore.patched_dateOfBirthComponents()
-  let dateOfBirth = vitalCalendar.date(from: components)
+  let dateOfBirth = try healthKitStore.patched_dateOfBirthComponents()
+    .flatMap(vitalCalendar.date(from:))
 
   let payload: [QuantitySample] = try await querySample(
     healthKitStore: healthKitStore,


### PR DESCRIPTION
`dateOfBirthComponents()` is not exposed to Swift correctly.

The scenario of "permission granted but DoB unset" is represented by `*error = nil` + returning `nil`. But this pattern is instead recognised (1) by the Swift-ObjC interop as erroring without any NSError; and (2) the Clang importer as non-null returning method.

Workaround the issue by catching the `Foundation._GenericObjCError` being thrown by the interop runtime in absence of an actual NSError.

Also explicitly set `Gregorian` on the date components when interpreting HealthKit-returned DoB, in case the current calendar is not Gregorian (rare but possible).