### PR TITLE
VIT-2513 BLE Glucose Service reader improvements

### DIFF
--- a/Examples/iOS/Devices Tab/Models/Devices+Support.swift
+++ b/Examples/iOS/Devices Tab/Models/Devices+Support.swift
@@ -26,9 +26,12 @@ func url(for device: DeviceModel) -> URL {
     
     case "Beurer Devices":
       image = "https://storage.googleapis.com/vital-assets/beurer_devices.png"
-      
+
     case "Freestyle Libre 1":
       image = "https://storage.googleapis.com/vital-assets/libre1.png"
+
+    case "Vital BLE Simulator":
+      image = "https://storage.googleapis.com/vital-assets/accu_check_active.png"
       
     default:
       fatalError("Device not supported")

--- a/Sources/VitalDevices/DeviceManager+Brands.swift
+++ b/Sources/VitalDevices/DeviceManager+Brands.swift
@@ -2,6 +2,9 @@ import CoreBluetooth
 import VitalCore
 
 public extension DevicesManager {
+  /// Special string to detect the Vital BLE simulator entry.
+  static let vitalBLESimulator = "$vital_ble_simulator$"
+
   static func devices(for brand: Brand) -> [DeviceModel] {
     return [
       .init(
@@ -51,7 +54,13 @@ public extension DevicesManager {
         name: "Freestyle Libre 1",
         brand: .libre,
         kind: .glucoseMeter
-      )
+      ),
+      .init(
+        id: Self.vitalBLESimulator,
+        name: "Vital BLE Simulator",
+        brand: .accuChek,
+        kind: .glucoseMeter
+      ),
     ].filter {
       $0.brand == brand
     }
@@ -69,6 +78,8 @@ public extension DevicesManager {
         return ["meter"]
       case "accuchek_guide_active":
         return ["meter"]
+      case Self.vitalBLESimulator:
+        return [Self.vitalBLESimulator]
       case "contour_next_one":
         return ["contour"]
       case "beurer":

--- a/Sources/VitalDevices/DeviceManager.swift
+++ b/Sources/VitalDevices/DeviceManager.swift
@@ -38,14 +38,11 @@ public class DevicesManager {
         }
         
         let codes = DevicesManager.codes(for: deviceModel.id)
-        let outcome = codes.reduce(false) { partialResult, code in
-          guard partialResult == false else {
-            return true
-          }
-          
-          return name.lowercased().contains(code.lowercased())
-        }
-        
+
+        let lowercasedName = name.lowercased()
+        let outcome = codes.contains { lowercasedName.contains($0.lowercased()) }
+          || codes.contains(Self.vitalBLESimulator)
+
         guard outcome else {
           return nil
         }

--- a/Sources/VitalDevices/DeviceReading/BloodPressureReader1810.swift
+++ b/Sources/VitalDevices/DeviceReading/BloodPressureReader1810.swift
@@ -16,7 +16,7 @@ class BloodPressureReader1810: BloodPressureReadable {
   
   init(manager: CentralManager = .live(), queue: DispatchQueue) {
     self.manager = manager
-    self.queue = queue
+    self.queue = DispatchQueue(label: "co.tryvital.VitalDevices.BloodPressureReader1810", target: queue)
   }
   
   public func read(device: ScannedDevice) -> AnyPublisher<[BloodPressureSample], Error> {
@@ -37,7 +37,7 @@ class BloodPressureReader1810: BloodPressureReadable {
       .didUpdateState.filter { state in
         state == .poweredOn
       }
-      .mapError { $0 as Error }
+      .mapError { _ -> Error in }
       .eraseToAnyPublisher()
     
     if manager.state == .poweredOn {

--- a/Sources/VitalDevices/DeviceReading/BloodPressureReader1810.swift
+++ b/Sources/VitalDevices/DeviceReading/BloodPressureReader1810.swift
@@ -16,7 +16,7 @@ class BloodPressureReader1810: BloodPressureReadable {
   
   init(manager: CentralManager = .live(), queue: DispatchQueue) {
     self.manager = manager
-    self.queue = DispatchQueue(label: "co.tryvital.VitalDevices.BloodPressureReader1810", target: queue)
+    self.queue = DispatchQueue(label: "io.tryvital.VitalDevices.BloodPressureReader1810", target: queue)
   }
   
   public func read(device: ScannedDevice) -> AnyPublisher<[BloodPressureSample], Error> {

--- a/Sources/VitalDevices/DeviceReading/Errors.swift
+++ b/Sources/VitalDevices/DeviceReading/Errors.swift
@@ -1,0 +1,15 @@
+public struct BluetoothRACPError: Error {
+  public let code: Int
+
+  public init(code: Int) {
+    self.code = code
+  }
+}
+
+public struct BluetoothError: Error {
+  public let message: String
+
+  public init(message: String) {
+    self.message = message
+  }
+}

--- a/Sources/VitalDevices/DeviceReading/GlucoseMeter1808.swift
+++ b/Sources/VitalDevices/DeviceReading/GlucoseMeter1808.swift
@@ -17,7 +17,7 @@ class GlucoseMeter1808: GlucoseMeterReadable {
   
   init(manager: CentralManager = .live(), queue: DispatchQueue) {
     self.manager = manager
-    self.queue = DispatchQueue(label: "co.tryvital.VitalDevices.GlucoseMeter1808", target: queue)
+    self.queue = DispatchQueue(label: "io.tryvital.VitalDevices.GlucoseMeter1808", target: queue)
   }
 
   func read(device: ScannedDevice) -> AnyPublisher<[QuantitySample], Error> {
@@ -140,6 +140,9 @@ class GlucoseMeter1808: GlucoseMeterReadable {
 }
 
 private func toGlucoseReading(data: Data?) -> QuantitySample? {
+  /// Record size is minimum 10 bytes (all mandatory fields)
+  /// Size can vary based on flags encoded in the first byte.
+  /// Refer to Bluetooth Glucose Service specification for more information.
   guard let data = data, data.count >= 10 else {
     return nil
   }

--- a/Sources/VitalDevices/DeviceReading/RACPResponse.swift
+++ b/Sources/VitalDevices/DeviceReading/RACPResponse.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+enum RACPResponse {
+  case success
+  case noRecordsFound
+  case notCompleted
+  case unknown(code: UInt8)
+
+  case invalidPayloadStructure
+
+  var code: Int {
+    switch self {
+    case .success:
+      return 1
+    case .noRecordsFound:
+      return 6
+    case .notCompleted:
+      return 8
+    case let .unknown(code):
+      return Int(code)
+    case .invalidPayloadStructure:
+      return -1
+    }
+  }
+
+  init(data: Data) {
+    // byte 0 (opcode) must be 6; byte 1 (operator) must be 0 (null).
+    guard data.count >= 3, data[0] == 6, data[1] == 0 else {
+      self = .invalidPayloadStructure
+      return
+    }
+
+    let responseCode = data[2]
+
+    switch responseCode {
+    case 1:
+      self = .success
+    case 6:
+      self = .noRecordsFound
+    case 8:
+      self = .notCompleted
+    default:
+      self = .unknown(code: responseCode)
+    }
+  }
+}

--- a/Sources/VitalDevices/Models/SFloat.swift
+++ b/Sources/VitalDevices/Models/SFloat.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+internal enum SFloat {
+  enum ReservedValue: Int16 {
+    case positiveInfinity = 0x07FE
+    case nan = 0x07FF
+    case nres = 0x0800
+    case reservedValue = 0x0801
+    case negativeInfinity = 0x0802
+
+    var doubleValue: Double {
+      switch self {
+      case .positiveInfinity:
+        return .infinity
+      case .negativeInfinity:
+        return -.infinity
+      case .reservedValue, .nres, .nan:
+        return .nan
+      }
+    }
+  }
+
+  static func read(data: UInt16) -> Double {
+    var mantissa = Int16(data & 0x0FFF)
+    var expoent = Int8(data >> 12)
+
+    if let reservedValue = ReservedValue(rawValue: mantissa) {
+      return reservedValue.doubleValue
+    }
+
+    if expoent >= 0x0008 {
+      expoent = -((0x000F + 1) - expoent)
+    }
+
+    if mantissa >= 0x0800 {
+      mantissa = -((0x0FFF + 1) - mantissa)
+    }
+
+    let magnitude = pow(10.0, Double(expoent))
+    return Double(mantissa) * magnitude
+  }
+}


### PR DESCRIPTION
Improve the BLE Glucose Service (1808) reader in VitalDevices:

1. Fixed unit handling: Now handles both kg/L and mol/L correctly as per BLE spec.

2. Fixed binary payload decoding: Respect flags and optional frames; handle the sfloat format correctly.

3. The `GlucoseMeter.read(device:)` publisher now either completes with one batch of all stored records, or error out. This is new change from the current behaviour (never ending publisher, with samples in chunks). 

    * This is achieved by listening to the RACP response indication (notification), which must be issued by a compliant device after they have finished sending out all the measurements via BLE notifications, or when an error is encountered.

4. Added device support for Vital BLE Simulator.


Note: Blood Pressure service to be improved separately