### PR TITLE
VIT-2518 BLE Simulator for Glucose Monitor

### DIFF
--- a/BLEMonitorSimulator/BLEMonitorSimulator.xcodeproj/project.pbxproj
+++ b/BLEMonitorSimulator/BLEMonitorSimulator.xcodeproj/project.pbxproj
@@ -1,0 +1,479 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9A25BB40299A81FD0019D0BA /* BLEMonitorSimulatorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A25BB3F299A81FD0019D0BA /* BLEMonitorSimulatorApp.swift */; };
+		9A25BB42299A81FD0019D0BA /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A25BB41299A81FD0019D0BA /* ContentView.swift */; };
+		9A25BB44299A81FE0019D0BA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A25BB43299A81FE0019D0BA /* Assets.xcassets */; };
+		9A25BB47299A81FE0019D0BA /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A25BB46299A81FE0019D0BA /* Preview Assets.xcassets */; };
+		9A25BB4E299A82100019D0BA /* GlucoseMonitorSimulation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A25BB4D299A82100019D0BA /* GlucoseMonitorSimulation.swift */; };
+		9A25BB50299A95C90019D0BA /* SFloat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A25BB4F299A95C90019D0BA /* SFloat.swift */; };
+		9A25BB58299A9D170019D0BA /* SFloatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A25BB57299A9D170019D0BA /* SFloatTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		9A25BB59299A9D170019D0BA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9A25BB34299A81FD0019D0BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9A25BB3B299A81FD0019D0BA;
+			remoteInfo = GlocuseMonitorSim;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		9A25BB3C299A81FD0019D0BA /* BLEMonitorSimulator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BLEMonitorSimulator.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A25BB3F299A81FD0019D0BA /* BLEMonitorSimulatorApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLEMonitorSimulatorApp.swift; sourceTree = "<group>"; };
+		9A25BB41299A81FD0019D0BA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		9A25BB43299A81FE0019D0BA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9A25BB46299A81FE0019D0BA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		9A25BB4D299A82100019D0BA /* GlucoseMonitorSimulation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseMonitorSimulation.swift; sourceTree = "<group>"; };
+		9A25BB4F299A95C90019D0BA /* SFloat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFloat.swift; sourceTree = "<group>"; };
+		9A25BB55299A9D170019D0BA /* BLEMonitorSimulatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BLEMonitorSimulatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A25BB57299A9D170019D0BA /* SFloatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFloatTests.swift; sourceTree = "<group>"; };
+		9A620235299AAAE9000814D8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9A25BB39299A81FD0019D0BA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A25BB52299A9D170019D0BA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9A25BB33299A81FD0019D0BA = {
+			isa = PBXGroup;
+			children = (
+				9A25BB3E299A81FD0019D0BA /* BLEMonitorSimulator */,
+				9A25BB56299A9D170019D0BA /* BLEMonitorSimulatorTests */,
+				9A25BB3D299A81FD0019D0BA /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9A25BB3D299A81FD0019D0BA /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9A25BB3C299A81FD0019D0BA /* BLEMonitorSimulator.app */,
+				9A25BB55299A9D170019D0BA /* BLEMonitorSimulatorTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9A25BB3E299A81FD0019D0BA /* BLEMonitorSimulator */ = {
+			isa = PBXGroup;
+			children = (
+				9A620235299AAAE9000814D8 /* Info.plist */,
+				9A25BB3F299A81FD0019D0BA /* BLEMonitorSimulatorApp.swift */,
+				9A25BB41299A81FD0019D0BA /* ContentView.swift */,
+				9A25BB43299A81FE0019D0BA /* Assets.xcassets */,
+				9A25BB45299A81FE0019D0BA /* Preview Content */,
+				9A25BB4D299A82100019D0BA /* GlucoseMonitorSimulation.swift */,
+				9A25BB4F299A95C90019D0BA /* SFloat.swift */,
+			);
+			path = BLEMonitorSimulator;
+			sourceTree = "<group>";
+		};
+		9A25BB45299A81FE0019D0BA /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				9A25BB46299A81FE0019D0BA /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		9A25BB56299A9D170019D0BA /* BLEMonitorSimulatorTests */ = {
+			isa = PBXGroup;
+			children = (
+				9A25BB57299A9D170019D0BA /* SFloatTests.swift */,
+			);
+			path = BLEMonitorSimulatorTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9A25BB3B299A81FD0019D0BA /* BLEMonitorSimulator */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A25BB4A299A81FE0019D0BA /* Build configuration list for PBXNativeTarget "BLEMonitorSimulator" */;
+			buildPhases = (
+				9A25BB38299A81FD0019D0BA /* Sources */,
+				9A25BB39299A81FD0019D0BA /* Frameworks */,
+				9A25BB3A299A81FD0019D0BA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BLEMonitorSimulator;
+			productName = GlocuseMonitorSim;
+			productReference = 9A25BB3C299A81FD0019D0BA /* BLEMonitorSimulator.app */;
+			productType = "com.apple.product-type.application";
+		};
+		9A25BB54299A9D170019D0BA /* BLEMonitorSimulatorTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A25BB5B299A9D170019D0BA /* Build configuration list for PBXNativeTarget "BLEMonitorSimulatorTests" */;
+			buildPhases = (
+				9A25BB51299A9D170019D0BA /* Sources */,
+				9A25BB52299A9D170019D0BA /* Frameworks */,
+				9A25BB53299A9D170019D0BA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9A25BB5A299A9D170019D0BA /* PBXTargetDependency */,
+			);
+			name = BLEMonitorSimulatorTests;
+			productName = GlocuseMonitorSimTests;
+			productReference = 9A25BB55299A9D170019D0BA /* BLEMonitorSimulatorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9A25BB34299A81FD0019D0BA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1420;
+				LastUpgradeCheck = 1420;
+				TargetAttributes = {
+					9A25BB3B299A81FD0019D0BA = {
+						CreatedOnToolsVersion = 14.2;
+					};
+					9A25BB54299A9D170019D0BA = {
+						CreatedOnToolsVersion = 14.2;
+						TestTargetID = 9A25BB3B299A81FD0019D0BA;
+					};
+				};
+			};
+			buildConfigurationList = 9A25BB37299A81FD0019D0BA /* Build configuration list for PBXProject "BLEMonitorSimulator" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 9A25BB33299A81FD0019D0BA;
+			productRefGroup = 9A25BB3D299A81FD0019D0BA /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9A25BB3B299A81FD0019D0BA /* BLEMonitorSimulator */,
+				9A25BB54299A9D170019D0BA /* BLEMonitorSimulatorTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		9A25BB3A299A81FD0019D0BA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A25BB47299A81FE0019D0BA /* Preview Assets.xcassets in Resources */,
+				9A25BB44299A81FE0019D0BA /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A25BB53299A9D170019D0BA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9A25BB38299A81FD0019D0BA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A25BB50299A95C90019D0BA /* SFloat.swift in Sources */,
+				9A25BB42299A81FD0019D0BA /* ContentView.swift in Sources */,
+				9A25BB4E299A82100019D0BA /* GlucoseMonitorSimulation.swift in Sources */,
+				9A25BB40299A81FD0019D0BA /* BLEMonitorSimulatorApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A25BB51299A9D170019D0BA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A25BB58299A9D170019D0BA /* SFloatTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		9A25BB5A299A9D170019D0BA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9A25BB3B299A81FD0019D0BA /* BLEMonitorSimulator */;
+			targetProxy = 9A25BB59299A9D170019D0BA /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		9A25BB48299A81FE0019D0BA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		9A25BB49299A81FE0019D0BA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		9A25BB4B299A81FE0019D0BA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"BLEMonitorSimulator/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BLEMonitorSimulator/Info.plist;
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Simulate a BLE glucose monitor.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tryvital.ios.BLEMonitorSimulator;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9A25BB4C299A81FE0019D0BA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"BLEMonitorSimulator/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BLEMonitorSimulator/Info.plist;
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Simulate a BLE glucose monitor.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tryvital.ios.BLEMonitorSimulator;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		9A25BB5C299A9D170019D0BA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tryvital.BLEMonitorSimulatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BLEMonitorSimulator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/BLEMonitorSimulator";
+			};
+			name = Debug;
+		};
+		9A25BB5D299A9D170019D0BA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tryvital.BLEMonitorSimulatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BLEMonitorSimulator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/BLEMonitorSimulator";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9A25BB37299A81FD0019D0BA /* Build configuration list for PBXProject "BLEMonitorSimulator" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A25BB48299A81FE0019D0BA /* Debug */,
+				9A25BB49299A81FE0019D0BA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9A25BB4A299A81FE0019D0BA /* Build configuration list for PBXNativeTarget "BLEMonitorSimulator" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A25BB4B299A81FE0019D0BA /* Debug */,
+				9A25BB4C299A81FE0019D0BA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9A25BB5B299A9D170019D0BA /* Build configuration list for PBXNativeTarget "BLEMonitorSimulatorTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A25BB5C299A9D170019D0BA /* Debug */,
+				9A25BB5D299A9D170019D0BA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 9A25BB34299A81FD0019D0BA /* Project object */;
+}

--- a/BLEMonitorSimulator/BLEMonitorSimulator.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/BLEMonitorSimulator/BLEMonitorSimulator.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:/Users/anders/repos/vital-ios/BLEMonitorSimulator/BLEMonitorSimulator.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/BLEMonitorSimulator/BLEMonitorSimulator.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BLEMonitorSimulator/BLEMonitorSimulator.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/BLEMonitorSimulator/BLEMonitorSimulator.xcodeproj/xcshareddata/xcschemes/BLEMonitorSimulator.xcscheme
+++ b/BLEMonitorSimulator/BLEMonitorSimulator.xcodeproj/xcshareddata/xcschemes/BLEMonitorSimulator.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9A25BB3B299A81FD0019D0BA"
+               BuildableName = "BLEMonitorSimulator.app"
+               BlueprintName = "BLEMonitorSimulator"
+               ReferencedContainer = "container:BLEMonitorSimulator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9A25BB54299A9D170019D0BA"
+               BuildableName = "BLEMonitorSimulatorTests.xctest"
+               BlueprintName = "BLEMonitorSimulatorTests"
+               ReferencedContainer = "container:BLEMonitorSimulator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9A25BB3B299A81FD0019D0BA"
+            BuildableName = "BLEMonitorSimulator.app"
+            BlueprintName = "BLEMonitorSimulator"
+            ReferencedContainer = "container:BLEMonitorSimulator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9A25BB3B299A81FD0019D0BA"
+            BuildableName = "BLEMonitorSimulator.app"
+            BlueprintName = "BLEMonitorSimulator"
+            ReferencedContainer = "container:BLEMonitorSimulator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BLEMonitorSimulator/BLEMonitorSimulator/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/BLEMonitorSimulator/BLEMonitorSimulator/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BLEMonitorSimulator/BLEMonitorSimulator/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/BLEMonitorSimulator/BLEMonitorSimulator/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BLEMonitorSimulator/BLEMonitorSimulator/Assets.xcassets/Contents.json
+++ b/BLEMonitorSimulator/BLEMonitorSimulator/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BLEMonitorSimulator/BLEMonitorSimulator/BLEMonitorSimulatorApp.swift
+++ b/BLEMonitorSimulator/BLEMonitorSimulator/BLEMonitorSimulatorApp.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+@main
+struct BLEMonitorSimulatorApp: App {
+  @StateObject var simulation = GlucoseMonitorSimulation()
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView(
+        state: $simulation.state,
+        isAdvertising: $simulation.isAdvertising,
+        subscribers: $simulation.subscribers,
+        timeline: $simulation.timeline
+      )
+      .onAppear {
+        simulation.start()
+      }
+    }
+  }
+}

--- a/BLEMonitorSimulator/BLEMonitorSimulator/ContentView.swift
+++ b/BLEMonitorSimulator/BLEMonitorSimulator/ContentView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct ContentView: View {
+  @Binding var state: GlucoseMonitorSimulation.ManagerState
+  @Binding var isAdvertising: Bool
+  @Binding var subscribers: [UUID]
+  @Binding var timeline: [GlucoseMonitorSimulation.TimelineEntry]
+
+  var body: some View {
+    NavigationSplitView {
+      Text(String("state: " + String(describing: state)))
+      Text(String("is advertising: " + String(describing: isAdvertising)))
+      Text(String("subscribers: " + String(describing: subscribers.count)))
+
+      ForEach(subscribers, id: \.self) { subscriber in
+        Text(String(subscriber.uuidString))
+      }
+    } detail: {
+      Table(timeline.reversed()) {
+        TableColumn("Date", value: \.date.description)
+          .width(min: 150, ideal: 200, max: 250)
+        TableColumn("Event", value: \.text)
+      }
+    }
+    .navigationTitle("Timeline")
+  }
+}
+
+struct ContentView_Previews: PreviewProvider {
+  static var previews: some View {
+    ContentView(
+      state: .constant(.unknown),
+      isAdvertising: .constant(true),
+      subscribers: .constant([UUID()]),
+      timeline: .constant([
+        GlucoseMonitorSimulation.TimelineEntry(date: Date(timeIntervalSince1970: 1.0), text: "Entry")
+      ])
+    )
+  }
+}

--- a/BLEMonitorSimulator/BLEMonitorSimulator/GlucoseMonitorSimulation.swift
+++ b/BLEMonitorSimulator/BLEMonitorSimulator/GlucoseMonitorSimulation.swift
@@ -1,0 +1,261 @@
+import CoreBluetooth
+import Combine
+
+final class GlucoseMonitorSimulation: NSObject, ObservableObject {
+  static let localName = "meter"
+  static let notifyRetry: Duration = .milliseconds(16)
+
+  struct TimelineEntry: Hashable, Identifiable {
+    let date: Date
+    let text: String
+
+    var id: Date { date }
+  }
+
+  enum ManagerState: String {
+    case unknown
+    case resetting
+    case unsupported
+    case unauthorized
+    case poweredOff
+    case poweredOn
+
+    init(_ state: CBManagerState) {
+      switch state {
+      case .unknown:
+        self = .unknown
+      case .poweredOff:
+        self = .poweredOff
+      case .poweredOn:
+        self = .poweredOn
+      case .resetting:
+        self = .resetting
+      case .unauthorized:
+        self = .unauthorized
+      case .unsupported:
+        self = .unsupported
+      @unknown default:
+        self = .unknown
+      }
+    }
+  }
+
+  @Published var state: ManagerState = .unknown
+  @Published var isAdvertising: Bool = false
+  @Published var timeline: [TimelineEntry] = []
+  @Published var subscribers: [UUID] = []
+
+  private var manager: CBPeripheralManager!
+  private var service: CBMutableService!
+  private var measurement: CBMutableCharacteristic!
+  private var accessControl: CBMutableCharacteristic!
+
+  private var bag: Set<AnyCancellable> = []
+
+  override init() {
+    super.init()
+    manager = CBPeripheralManager(
+      delegate: self,
+      queue: .main
+    )
+
+    // service 1808
+    service = CBMutableService(type: CBUUID(string: "00001808-0000-1000-8000-00805f9b34fb"), primary: true)
+    
+    measurement = CBMutableCharacteristic(
+      type: .glucoseMeasurement,
+      properties: [.notify],
+      value: nil,
+      permissions: .readable
+    )
+    accessControl = CBMutableCharacteristic(
+      type: .recordAccessControlPoint,
+      properties: [.indicate, .write],
+      value: nil,
+      permissions: .writeEncryptionRequired
+    )
+
+    service.characteristics = [measurement, accessControl]
+  }
+
+  func start() {
+    $state.filter { $0 == .poweredOn }.first()
+      .sink { [weak self] _ in
+        guard let self = self else { return }
+
+        self.manager.add(self.service)
+
+        self.manager.startAdvertising([
+          CBAdvertisementDataLocalNameKey: Self.localName,
+          CBAdvertisementDataServiceUUIDsKey: [self.service.uuid]
+        ])
+      }
+      .store(in: &bag)
+  }
+
+  @MainActor
+  private func notifyStubValues(sequenceNumber: Int) async throws {
+    guard subscribers.count > 0 else {
+      self.timeline.append(TimelineEntry(date: Date.now, text: "No subscriber is present for measurement \(sequenceNumber). Aborted."))
+      throw CancellationError()
+    }
+
+    // Typical blood sugar level: 90-100 mg/dL
+    let valueInMgDL = Double((900 ... 1000).randomElement()!) / 10
+    // Convert it to kg/L as per BLE Glucose Service spec
+    let value = valueInMgDL / 100000
+
+    var data = Data()
+
+    // flag: 1 byte
+    // 0001b / 0x01: time offset present (in minutes)
+    // 0010b / 0x02: glucose data present
+    data.append(contentsOf: [0x03])
+
+    // sequence number: 2 bytes
+    data.append(contentsOf: UInt16(sequenceNumber).data(bytes: 2))
+
+    // basetime: 7 bytes
+    // - year: 2 bytes
+    // - month: 1 byte
+    // - day: 1 byte
+    // - hour: 1 byte
+    // - minute: 1 byte
+    // - second: 1 byte
+    let calendar = Calendar(identifier: .gregorian)
+    let component = calendar.dateComponents([.year, .month, .day], from: calendar.date(byAdding: .day, value: sequenceNumber, to: .now)!)
+    data.append(contentsOf: UInt16(component.year!).data(bytes: 2))
+    data.append(contentsOf: [UInt8(component.month!), UInt8(component.day!), 12, 34, 56])
+
+    // timeoffset: 2 bytes uint16, in minutes
+    data.append(contentsOf: UInt16(60).data(bytes: 2))
+
+    // glucose: 3 bytes
+    // - concentration: sfloat 2 bytes
+    // - typeAndSampleLocation: 1 bytes
+    data.append(contentsOf: SFloat.write(value: value).data(bytes: 2))
+    data.append(contentsOf: [0x00])
+
+    guard self.manager.updateValue(data, for: self.measurement, onSubscribedCentrals: nil) else {
+      self.timeline.append(TimelineEntry(date: Date.now, text: "Failed to notify measurement \(sequenceNumber). Retrying..."))
+
+      try await Task.sleep(for: Self.notifyRetry)
+      try await notifyStubValues(sequenceNumber: sequenceNumber)
+
+      return
+    }
+
+    self.timeline.append(TimelineEntry(date: Date.now, text: "Notified measurement \(sequenceNumber) with value \(value)."))
+  }
+}
+
+extension GlucoseMonitorSimulation: CBPeripheralManagerDelegate {
+  func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+    self.state = ManagerState(peripheral.state)
+    self.timeline.append(TimelineEntry(date: Date.now, text: "managed state changed to: \(self.state)"))
+  }
+
+  func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: Error?) {
+    self.isAdvertising = error == nil
+
+    if let error = error {
+      timeline.append(TimelineEntry(date: Date.now, text: "advertising failed to start: " + error.localizedDescription))
+    } else {
+      timeline.append(TimelineEntry(date: Date.now, text: "started advertising"))
+    }
+  }
+
+  func peripheralManager(_ peripheral: CBPeripheralManager, central: CBCentral, didSubscribeTo characteristic: CBCharacteristic) {
+    timeline.append(TimelineEntry(date: Date.now, text: "subscriber connected: \(central.identifier)"))
+
+    if !subscribers.contains(central.identifier) {
+      subscribers.append(central.identifier)
+    }
+  }
+
+  func peripheralManager(_ peripheral: CBPeripheralManager, central: CBCentral, didUnsubscribeFrom characteristic: CBCharacteristic) {
+    timeline.append(TimelineEntry(date: Date.now, text: "subscriber disconnected: \(central.identifier)"))
+
+    if let index = subscribers.firstIndex(of: central.identifier) {
+      subscribers.remove(at: index)
+    }
+  }
+
+  func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveWrite requests: [CBATTRequest]) {
+    for request in requests {
+      timeline.append(TimelineEntry(date: Date.now, text: "processing write request on characteristic \(request.characteristic.friendlyName) from subscriber \(request.central.identifier)"))
+
+      if request.characteristic.uuid == accessControl.uuid {
+        let data = request.value ?? Data()
+
+        // [requestcode, operator]
+        if data == Data([1, 1]) {
+          // Respond only to Read Histroical Records + All Records
+          peripheral.respond(to: request, withResult: .success)
+
+          Task { @MainActor in
+            do {
+              for index in 0 ..< 20 {
+                try await notifyStubValues(sequenceNumber: index)
+              }
+
+              // [opcode, operator, requestcode, respcode]
+              try await sendRACPResponse(data: Data([6, 0, 1, 1]), for: accessControl, to: request.central, using: peripheral)
+            } catch _ {
+              // [opcode, operator, requestcode, respcode]
+              try await sendRACPResponse(data: Data([6, 0, 1, 8]), for: accessControl, to: request.central, using: peripheral)
+            }
+          }
+        } else {
+          peripheral.respond(to: request, withResult: .requestNotSupported)
+        }
+      }
+    }
+  }
+
+  @MainActor
+  func sendRACPResponse(data: Data, for characteristics: CBMutableCharacteristic, to central: CBCentral, using manager: CBPeripheralManager) async throws {
+    let success = manager.updateValue(data, for: characteristics, onSubscribedCentrals: [central])
+
+    guard success else {
+      self.timeline.append(TimelineEntry(date: Date.now, text: "Failed to indicate \(characteristics.friendlyName) (data = \(data.hexString)) to \(central.identifier). Retrying..."))
+      try await Task.sleep(for: Self.notifyRetry)
+      try await sendRACPResponse(data: data, for: characteristics, to: central, using: manager)
+      return
+    }
+
+    self.timeline.append(TimelineEntry(date: Date.now, text: "Successfully indicated \(characteristics.friendlyName) (data = \(data.hexString)) to \(central.identifier)."))
+  }
+}
+
+extension CBUUID {
+  static var glucoseMeasurement: CBUUID {
+    CBUUID(string: "00002A18-0000-1000-8000-00805f9b34fb")
+  }
+
+  static var recordAccessControlPoint: CBUUID {
+    CBUUID(string: "00002A52-0000-1000-8000-00805f9b34fb")
+  }
+}
+
+extension CBCharacteristic {
+  var friendlyName: String {
+    let uuid = self.uuid
+
+    if uuid == .recordAccessControlPoint {
+      return "RACP"
+    }
+
+    if uuid == .glucoseMeasurement {
+      return "Glucose Meas."
+    }
+
+    return uuid.uuidString
+  }
+}
+
+extension Data {
+  var hexString: String {
+    map { byte in String(format: "%02X", byte) }.joined(separator: ",")
+  }
+}

--- a/BLEMonitorSimulator/BLEMonitorSimulator/Info.plist
+++ b/BLEMonitorSimulator/BLEMonitorSimulator/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>bluetooth-peripheral</string>
+	</array>
+</dict>
+</plist>

--- a/BLEMonitorSimulator/BLEMonitorSimulator/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/BLEMonitorSimulator/BLEMonitorSimulator/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BLEMonitorSimulator/BLEMonitorSimulator/SFloat.swift
+++ b/BLEMonitorSimulator/BLEMonitorSimulator/SFloat.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+extension BinaryInteger {
+  func data(bytes: UInt8) -> Data {
+    let byteCount = bitWidth / 8
+    precondition(bytes == byteCount)
+
+    return withUnsafeTemporaryAllocation(byteCount: byteCount, alignment: byteCount) { buffer in
+      buffer.baseAddress!.withMemoryRebound(to: Self.self, capacity: 1) { address in
+        address.initialize(to: self)
+      }
+
+      return Data(bytes: buffer.baseAddress!, count: buffer.count)
+    }
+  }
+}
+
+enum SFloat {
+  enum ReservedValue: Int16 {
+    case positiveInfinity = 0x07FE
+    case nan = 0x07FF
+    case nres = 0x0800
+    case reservedValue = 0x0801
+    case negativeInfinity = 0x0802
+
+    static func contains(_ value: Int16) -> Bool {
+      positiveInfinity.rawValue <= value && value <= negativeInfinity.rawValue
+    }
+
+    static func infinity(_ sign: FloatingPointSign) -> Self {
+      switch sign {
+      case .plus:
+        return .positiveInfinity
+      case .minus:
+        return .negativeInfinity
+      }
+    }
+
+    var doubleValue: Double {
+      switch self {
+      case .positiveInfinity:
+        return .infinity
+      case .negativeInfinity:
+        return -.infinity
+      case .reservedValue, .nres, .nan:
+        return .nan
+      }
+    }
+  }
+
+  /// (2^11 - 3) * 10^7
+  static let max: Double = 20450000000.0
+
+  /// -(2^11 - 3) * 10^7
+  static let min: Double = -max
+
+  /// 2^11 - 3
+  static let mantissaMax: Double = 0x07FD
+
+  /// 2^3 - 1
+  static let exponentMax: Int16 = 7
+
+  /// -2^3
+  static let exponentMin: Int16 = -8
+
+  /// 10^-8
+  static let epsilon: Double = 1e-8
+
+  /// 10 ^ upper(11 * log(2) / log(10))
+  static let precision: UInt32 = 10000
+
+
+  static func read(data: UInt16) -> Double {
+    var mantissa = Int16(data & 0x0FFF)
+    var expoent = Int8(data >> 12)
+
+    if let reservedValue = ReservedValue(rawValue: mantissa) {
+      return reservedValue.doubleValue
+    }
+
+    if expoent >= 0x0008 {
+      expoent = -((0x000F + 1) - expoent)
+    }
+
+    if mantissa >= 0x0800 {
+      mantissa = -((0x0FFF + 1) - mantissa)
+    }
+
+    let magnitude = pow(10.0, Double(expoent))
+    return Double(mantissa) * magnitude
+  }
+
+
+  static func write(value: Double) -> UInt16 {
+    guard !value.isNaN else { return UInt16(ReservedValue.nan.rawValue) }
+    guard value <= max else { return UInt16(ReservedValue.positiveInfinity.rawValue) }
+    guard min <= value else { return UInt16(ReservedValue.negativeInfinity.rawValue) }
+    guard value < -epsilon || epsilon < value else { return 0 }
+
+    let sign = value > 0.0 ? 1.0 : -1.0
+    var mantissa = abs(value)
+    var exponent: Int16 = 0 // Exponent of 10
+
+    // Scale up if the number is too large.
+    while (mantissa > mantissaMax) {
+      mantissa /= 10.0
+      exponent += 1
+
+      if (exponent > exponentMax) {
+        return UInt16(ReservedValue.infinity(value.sign).rawValue)
+      }
+    }
+
+    // Scale down if the number is too small.
+    while (mantissa < 1) {
+      mantissa *= 10
+      exponent -= 1
+
+      if (exponent < exponentMin) {
+        return 0
+      }
+    }
+
+    // Scale down if the number needs more precision.
+    let precision = Double(Self.precision)
+    var smantissa = (mantissa * precision).rounded()
+    var rmantissa = mantissa.rounded() * precision
+    var mdiff = abs(smantissa - rmantissa)
+
+    while mdiff > 0.5, exponentMin < exponent, (mantissa * 10) <= mantissaMax {
+      mantissa *= 10
+      exponent -= 1
+      smantissa = (mantissa * precision).rounded()
+      rmantissa = mantissa.rounded() * precision
+      mdiff = abs(smantissa - rmantissa)
+    }
+
+    let finalMantissa = Int16((sign * mantissa).rounded())
+    return UInt16(bitPattern: (exponent & 0xF) << 12) | UInt16(bitPattern: (finalMantissa & 0xFFF))
+  }
+}

--- a/BLEMonitorSimulator/BLEMonitorSimulatorTests/SFloatTests.swift
+++ b/BLEMonitorSimulator/BLEMonitorSimulatorTests/SFloatTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import BLEMonitorSimulator
+
+final class SFloatTests: XCTestCase {
+  func testSFloatRoundTrips() {
+    for value in stride(from: -1000.0, to: 1000.0, by: 0.01) {
+      XCTAssertEqual(SFloat.read(data: SFloat.write(value: value)), value, accuracy: 0.5)
+    }
+
+    for value in stride(from: -10000.0, to: 10000.0, by: 0.1) {
+      XCTAssertEqual(SFloat.read(data: SFloat.write(value: value)), value, accuracy: 5.0)
+    }
+
+    let max = SFloat.write(value: SFloat.max)
+    XCTAssertEqual(SFloat.read(data: max), SFloat.max)
+
+    let min = SFloat.write(value: SFloat.min)
+    XCTAssertEqual(SFloat.read(data: min), SFloat.min)
+
+    XCTAssertEqual(SFloat.read(data: SFloat.write(value: .infinity)), .infinity)
+    XCTAssertEqual(SFloat.read(data: SFloat.write(value: -.infinity)), -.infinity)
+    XCTAssert(SFloat.read(data: SFloat.write(value: .nan)).isNaN)
+  }
+
+  func testSFloatReservedValues() {
+    XCTAssertEqual(SFloat.read(data: 0x07FE), .infinity)
+    XCTAssert(SFloat.read(data: 0x07FF).isNaN)
+    XCTAssert(SFloat.read(data: 0x0800).isNaN)
+    XCTAssert(SFloat.read(data: 0x0801).isNaN)
+    XCTAssertEqual(SFloat.read(data: 0x0802), -.infinity)
+  }
+}


### PR DESCRIPTION
A Mac Catalyst app that emulates BLE Glucose Monitor service via Core Bluetooth.

* Requires #21 which added support for the "Vital BLE Simulator" device type.
* Does not fully implement the Service Specification, but only the parts where Vital Devices rely upon.

<img src="https://user-images.githubusercontent.com/11806295/218785758-2847f609-57c9-4539-9f09-08cba0422d2d.png" width="400" />

