### PR TITLE
VIT-2516 Factor out GATTMeter base class & reuse in BLE BP reader

### DIFF
--- a/Sources/VitalDevices/DeviceReading/BloodPressureReader1810.swift
+++ b/Sources/VitalDevices/DeviceReading/BloodPressureReader1810.swift
@@ -41,10 +41,11 @@ private func toBloodPressureReading(data: Data) -> BloodPressureSample? {
   let date = Calendar.current.date(from: components) ?? .init()
   
   let pulseRate: UInt16 = [byteArrayFromData[14], byteArrayFromData[15]].withUnsafeBytes { $0.load(as: UInt16.self) }
-  
-  let systolicSample = QuantitySample(value: Double(systolic), startDate: date, endDate: date, type: "cuff", unit: units)
-  let diastolicSample = QuantitySample(value: Double(diastolic), startDate: date, endDate: date, type: "cuff", unit: units)
-  let pulseSample = QuantitySample(value: Double(pulseRate), startDate: date, endDate: date, type: "cuff", unit: "bpm")
+
+  let idPrefix = "\(date.timeIntervalSince1970.rounded())-"
+  let systolicSample = QuantitySample(id: "\(idPrefix)systolic", value: Double(systolic), startDate: date, endDate: date, type: "cuff", unit: units)
+  let diastolicSample = QuantitySample(id: "\(idPrefix)diastolic", value: Double(diastolic), startDate: date, endDate: date, type: "cuff", unit: units)
+  let pulseSample = QuantitySample(id: "\(idPrefix)pulse", value: Double(pulseRate), startDate: date, endDate: date, type: "cuff", unit: "bpm")
   
   return BloodPressureSample(
     systolic: systolicSample,

--- a/Sources/VitalDevices/DeviceReading/BloodPressureReader1810.swift
+++ b/Sources/VitalDevices/DeviceReading/BloodPressureReader1810.swift
@@ -24,7 +24,12 @@ private func toBloodPressureReading(data: Data) -> BloodPressureSample? {
   guard data.count >= 16 else { return nil }
 
   let byteArrayFromData: [UInt8] = [UInt8](data)
-  
+  let isTimestampPresent = (byteArrayFromData[0] & 0x02) != 0
+
+  // We accept only stored Blood Pressure records with a timestamp (as suggested
+  // by BLE Blood Pressure Service specification v1.1.1).
+  guard isTimestampPresent else { return nil }
+
   let units = (byteArrayFromData[0] & 1) != 0 ? "kPa" : "mmHg"
   
   let systolic: UInt16 = [byteArrayFromData[1], byteArrayFromData[2]].withUnsafeBytes { $0.load(as: UInt16.self) }

--- a/Sources/VitalDevices/DeviceReading/GATTMeter.swift
+++ b/Sources/VitalDevices/DeviceReading/GATTMeter.swift
@@ -1,0 +1,132 @@
+import VitalCore
+import CombineCoreBluetooth
+import Combine
+
+internal class GATTMeter<Sample> {
+  // 2A52 is the assigned number for Record Access Control Point in GATT.
+  private let racpCharacteristicID = CBUUID(string: "2A52".fullUUID)
+
+  private let serviceID: CBUUID
+  private let measurementCharacteristicID: CBUUID
+
+  private let manager: CentralManager
+  private let queue: DispatchQueue
+
+  private let parser: (Data) -> Sample?
+
+  init(
+    manager: CentralManager,
+    queue: DispatchQueue,
+    serviceID: CBUUID,
+    measurementCharacteristicID: CBUUID,
+    parser: @escaping (Data) -> Sample?
+  ) {
+    self.manager = manager
+    self.queue = DispatchQueue(label: "io.tryvital.VitalDevices.\(Self.self)", target: queue)
+    self.serviceID = serviceID
+    self.measurementCharacteristicID = measurementCharacteristicID
+    self.parser = parser
+  }
+
+  func read(device: ScannedDevice) -> AnyPublisher<[Sample], Error> {
+    return _pair(device: device).flatMapLatest { (peripheral, characteristics) -> AnyPublisher<[Sample], Error> in
+        guard
+          let measurementCharacteristic = characteristics.first(where: { $0.uuid == self.measurementCharacteristicID }),
+          let RACPCharacteristic = characteristics.first(where: { $0.uuid == self.racpCharacteristicID })
+        else {
+          return Fail(outputType: [Sample].self, failure: BluetoothError(message: "Missing required characteristics."))
+            .eraseToAnyPublisher()
+        }
+        var cancellables: Set<AnyCancellable> = []
+
+        let write = peripheral.writeValue(Data([1, 1]), for: RACPCharacteristic, type: .withResponse)
+
+        let racpResponse = CurrentValueSubject<RACPResponse?, Error>(nil)
+        let racpSuccessOrFailure = racpResponse.compactMap { $0 }.first().tryMap { response in
+          switch response {
+          case .success, .noRecordsFound:
+            return ()
+          case .notCompleted, .unknown, .invalidPayloadStructure:
+            throw BluetoothRACPError(code: response.code)
+          }
+        }
+
+        // (1) We first start listening for measurement notifications
+        return peripheral
+          .listenForUpdates(on: measurementCharacteristic)
+          .compactMap { $0.flatMap(self.parser) }
+          .prefix(untilOutputFrom: racpSuccessOrFailure)
+          .collect()
+          .handleEvents(
+            receiveSubscription: { _ in
+              // (2) We then start listening for RACP response indication
+              peripheral
+                .listenForUpdates(on: RACPCharacteristic)
+                .map { $0.map(RACPResponse.init) ?? .invalidPayloadStructure }
+                .subscribe(racpResponse)
+                .store(in: &cancellables)
+
+              // (3) We finally write to RACP to initiate the Load All Records operation.
+              write
+                .sink(receiveCompletion: { _ in }, receiveValue: {})
+                .store(in: &cancellables)
+            },
+            receiveCompletion: { _ in
+              cancellables.forEach { $0.cancel() }
+            },
+            receiveCancel: {
+              cancellables.forEach { $0.cancel() }
+            }
+          )
+          .eraseToAnyPublisher()
+    }
+  }
+
+  func pair(device: ScannedDevice) -> AnyPublisher<Void, Error> {
+    _pair(device: device).map { _ in ()}.eraseToAnyPublisher()
+  }
+
+  private func _pair(device: ScannedDevice) -> AnyPublisher<(Peripheral, [CBCharacteristic]), Error> {
+    let isOn = manager
+      .didUpdateState
+      .prepend(manager.state)
+      .filter { $0 == .poweredOn }
+      .first()
+      .mapError { _ -> Error in }
+
+    return isOn
+      .flatMap { _ in self._connectAndDiscoverCharacteristics(for: device) }
+      .eraseToAnyPublisher()
+  }
+
+  private func _connectAndDiscoverCharacteristics(
+    for device: ScannedDevice
+  ) -> AnyPublisher<(Peripheral, [CBCharacteristic]), Error> {
+    return manager.connect(device.peripheral).flatMapLatest { peripheral -> AnyPublisher<(Peripheral, [CBCharacteristic]), Error> in
+      peripheral.discoverServices([self.serviceID])
+        .flatMapLatest { services -> AnyPublisher<[CBCharacteristic], Error> in
+          guard services.isEmpty == false else {
+            return .empty
+          }
+
+          return peripheral.discoverCharacteristics([self.measurementCharacteristicID, self.racpCharacteristicID], for: services[0])
+        }
+        .flatMapLatest { characteristics -> AnyPublisher<(Peripheral, [CBCharacteristic]), Error> in
+          guard characteristics.count == 2 else {
+            return .empty
+          }
+          let second = peripheral.setNotifyValue(true, for: characteristics[1])
+          let first = peripheral.setNotifyValue(true, for: characteristics[0])
+
+          let zipped = first.zip(second).first().eraseToAnyPublisher()
+
+          return zipped.map { _ in
+            return (peripheral, characteristics)
+          }
+          .eraseToAnyPublisher()
+        }
+    }
+    .eraseToAnyPublisher()
+  }
+}
+

--- a/Sources/VitalDevices/DeviceReading/GlucoseMeter1808.swift
+++ b/Sources/VitalDevices/DeviceReading/GlucoseMeter1808.swift
@@ -6,144 +6,26 @@ public protocol GlucoseMeterReadable: DevicePairable {
   func read(device: ScannedDevice) -> AnyPublisher<[QuantitySample], Error>
 }
 
-private let service = CBUUID(string: "1808")
-private let measurementCharacteristicUUID = CBUUID(string: "2A18".fullUUID)
-private let RACPCharacteristicUUID = CBUUID(string: "2A52".fullUUID)
-
-class GlucoseMeter1808: GlucoseMeterReadable {
-  
-  private let manager: CentralManager
-  private let queue: DispatchQueue
-  
-  init(manager: CentralManager = .live(), queue: DispatchQueue) {
-    self.manager = manager
-    self.queue = DispatchQueue(label: "io.tryvital.VitalDevices.GlucoseMeter1808", target: queue)
-  }
-
-  func read(device: ScannedDevice) -> AnyPublisher<[QuantitySample], Error> {
-    return _pair(device: device).flatMapLatest { (peripheral, characteristics) -> AnyPublisher<[QuantitySample], Error> in
-        guard
-          let measurementCharacteristic = characteristics.first(where: { $0.uuid == measurementCharacteristicUUID }),
-          let RACPCharacteristic = characteristics.first(where: { $0.uuid == RACPCharacteristicUUID })
-        else {
-          return Fail(outputType: [QuantitySample].self, failure: BluetoothError(message: "Missing required characteristics."))
-            .eraseToAnyPublisher()
-        }
-        var cancellables: Set<AnyCancellable> = []
-
-        let write = peripheral.writeValue(Data([1, 1]), for: RACPCharacteristic, type: .withResponse)
-
-        let racpResponse = CurrentValueSubject<RACPResponse?, Error>(nil)
-        let racpSuccessOrFailure = racpResponse.compactMap { $0 }.first().tryMap { response in
-          switch response {
-          case .success, .noRecordsFound:
-            return ()
-          case .notCompleted, .unknown, .invalidPayloadStructure:
-            throw BluetoothRACPError(code: response.code)
-          }
-        }
-
-        // (1) We first start listening for measurement notifications
-        return peripheral
-          .listenForUpdates(on: measurementCharacteristic)
-          .compactMap(toGlucoseReading)
-          .prefix(untilOutputFrom: racpSuccessOrFailure)
-          .collect()
-          .handleEvents(
-            receiveSubscription: { _ in
-              // (2) We then start listening for RACP response indication
-              peripheral
-                .listenForUpdates(on: RACPCharacteristic)
-                .map { $0.map(RACPResponse.init) ?? .invalidPayloadStructure }
-                .subscribe(racpResponse)
-                .store(in: &cancellables)
-
-              // (3) We finally write to RACP to initiate the Load All Records operation.
-              write
-                .sink(receiveCompletion: { _ in }, receiveValue: {})
-                .store(in: &cancellables)
-            },
-            receiveCompletion: { _ in
-              cancellables.forEach { $0.cancel() }
-            },
-            receiveCancel: {
-              cancellables.forEach { $0.cancel() }
-            }
-          )
-          .eraseToAnyPublisher()
-    }
-  }
-
-  func pair(device: ScannedDevice) -> AnyPublisher<Void, Error> {
-    _pair(device: device).map { _ in ()}.eraseToAnyPublisher()
-  }
-  
-  private func _pair(device: ScannedDevice) -> AnyPublisher<(Peripheral, [CBCharacteristic]), Error> {
-    let isOn: AnyPublisher<CBManagerState, Error> = manager
-      .didUpdateState.filter { state in
-        state == .poweredOn
-      }
-      .mapError { _ -> Error in }
-      .eraseToAnyPublisher()
-    
-    if manager.state == .poweredOn {
-      return GlucoseMeter1808._pair(
-        manager: manager,
-        device: device,
-        measurementCharacteristicUUID: measurementCharacteristicUUID,
-        RACPCharacteristicUUID: RACPCharacteristicUUID
-      )
-    } else {
-      return isOn.flatMapLatest { [manager] _ in
-        return GlucoseMeter1808._pair(
-          manager: manager,
-          device: device,
-          measurementCharacteristicUUID: measurementCharacteristicUUID,
-          RACPCharacteristicUUID: RACPCharacteristicUUID
-        )
-      }
-    }
-  }
-  
-  private static func _pair(
-    manager: CentralManager,
-    device: ScannedDevice,
-    measurementCharacteristicUUID: CBUUID,
-    RACPCharacteristicUUID: CBUUID
-  ) -> AnyPublisher<(Peripheral, [CBCharacteristic]), Error> {
-    return manager.connect(device.peripheral).flatMapLatest { peripheral -> AnyPublisher<(Peripheral, [CBCharacteristic]), Error> in
-      peripheral.discoverServices([service])
-        .flatMapLatest { services -> AnyPublisher<[CBCharacteristic], Error> in
-          guard services.isEmpty == false else {
-            return .empty
-          }
-          
-          return peripheral.discoverCharacteristics([measurementCharacteristicUUID, RACPCharacteristicUUID], for: services[0])
-        }
-        .flatMapLatest { characteristics -> AnyPublisher<(Peripheral, [CBCharacteristic]), Error> in
-          guard characteristics.count == 2 else {
-            return .empty
-          }
-          let second = peripheral.setNotifyValue(true, for: characteristics[1])
-          let first = peripheral.setNotifyValue(true, for: characteristics[0])
-
-          let zipped = first.zip(second).first().eraseToAnyPublisher()
-          
-          return zipped.map { _ in
-            return (peripheral, characteristics)
-          }
-          .eraseToAnyPublisher()
-        }
-    }
-    .eraseToAnyPublisher()
+class GlucoseMeter1808: GATTMeter<QuantitySample>, GlucoseMeterReadable {
+  init(
+    manager: CentralManager = .live(),
+    queue: DispatchQueue
+  ) {
+    super.init(
+      manager: manager,
+      queue: queue,
+      serviceID: CBUUID(string: "1808".fullUUID),
+      measurementCharacteristicID: CBUUID(string: "2A18".fullUUID),
+      parser: toGlucoseReading(data:)
+    )
   }
 }
 
-private func toGlucoseReading(data: Data?) -> QuantitySample? {
+private func toGlucoseReading(data: Data) -> QuantitySample? {
   /// Record size is minimum 10 bytes (all mandatory fields)
   /// Size can vary based on flags encoded in the first byte.
   /// Refer to Bluetooth Glucose Service specification for more information.
-  guard let data = data, data.count >= 10 else {
+  guard data.count >= 10 else {
     return nil
   }
 

--- a/Sources/VitalDevices/DeviceReading/GlucoseMeter1808.swift
+++ b/Sources/VitalDevices/DeviceReading/GlucoseMeter1808.swift
@@ -84,7 +84,9 @@ private func toGlucoseReading(data: Data) -> QuantitySample? {
   }
 
   return QuantitySample(
-    id: "\(sequenceNumber)",
+    // Prefixed with epoch in seconds to avoid sequence number conflicts
+    // (due to new device and/or device reset)
+    id: "\(date.timeIntervalSince1970.rounded())-\(sequenceNumber)",
     value: value,
     startDate: date,
     endDate: date,


### PR DESCRIPTION
Apply improvements in #21 to the Blood Pressure reader as well, by factoring out the common a BLE GATT Service reader implementation.