### PR TITLE
[VIT-2593] Support listing currently connected BLE devices

### DIFF
--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -151,6 +151,14 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       apiVersion: "v2"
     )
   }
+
+  public static var isConfigured: Bool {
+    get async {
+      guard !(await self.shared.userId.isNil()) else { return false }
+      guard !(await self.shared.configuration.isNil()) else { return false }
+      return true
+    }
+  }
   
   public static func automaticConfiguration() async {
     do {


### PR DESCRIPTION
## New API to list currently connected BLE devices

Create an iOS equivalent of vital-android's new `VitalDevicesManager.connected(DeviceModel)` in https://github.com/tryVital/vital-android/pull/15.

API consumers can query currently connected BLE devices via `connected(DeviceModel)`. On iOS, connections can reset upon app being backgrounded/suspended/termination, so not all paired devices would show up w/o re-scanning.

Note that Android has a stronger semantic with this API, since the Android BLE stack would persistently report also paired-but-disconnected devices, but we are framing this as "connected devices" for platform parity.

This is useful for speeding up device listing (when connected) and general troubleshooting.


## New `VitalClient.Type.isConfigured` API for introspection

An introspection API to check if the SDK has been configured or not.

For example, the example app Device screen now uses this to provide a proactive alert of SDK not having been configured, instead of being stuck indefinitely waiting for the connected source creation API to return.

## Updated the example app Device screen

* The Device screen now surfaces to the user any error messages reported by underlying API call failures, including the aforementioned "SDK not configured" error.

* The Device screen now tracks ConnectedSource creation (and its failure) as separate statuses from the BLE device scanning.