### PR TITLE
Statistics with HealthKit source merging

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -260,7 +260,7 @@ struct StatisticsQueryDependencies {
       )
 
       // While we are interested in the contributing sources, we should not use
-      // the `sepearateBySource` option, as we want HealthKit to provide
+      // the `separateBySource` option, as we want HealthKit to provide
       // final statistics points that are merged from all data sources.
       //
       // We will issue a separate HKSourceQuery to lookup the contributing

--- a/Sources/VitalHealthKit/HealthKit/Storage/VitalStatistics.swift
+++ b/Sources/VitalHealthKit/HealthKit/Storage/VitalStatistics.swift
@@ -29,13 +29,9 @@ struct VitalStatistics {
     self.sources = sources
   }
     
-  init?(statistics: HKStatistics, type: HKQuantityType) {
+  init?(statistics: HKStatistics, type: HKQuantityType, sources: [String]) {
     guard let sum = statistics.sumQuantity() else {
       return nil
-    }
-    
-    let sources: [String]? = statistics.sources?.compactMap { source in
-      source.bundleIdentifier
     }
     
     let value = sum.doubleValue(for: type.toHealthKitUnits)
@@ -44,7 +40,7 @@ struct VitalStatistics {
       type: String(describing: type),
       startDate: statistics.startDate,
       endDate: statistics.endDate,
-      sources: sources ?? []
+      sources: sources
     )
   }
 }

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -298,7 +298,7 @@ extension VitalHealthKitClient {
     await store.disableBackgroundDelivery()
     backgroundDeliveryTask?.cancel()
     
-    await backgroundDeliveryEnabled.set(value: false)
+    backgroundDeliveryEnabled.set(value: false)
     
     await VitalClient.shared.cleanUp()
     self.secureStorage.clean(key: health_secureStorageKey)

--- a/Tests/VitalHealthKitTests/VitalHealthKitClientTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitClientTests.swift
@@ -6,9 +6,9 @@ import HealthKit
 
 class VitalHealthKitClientTests: XCTestCase {
   
-  func testSetupWithoutVitalClient() async throws {
+  func testSetupWithoutVitalClient() {
     /// This shouldn't crash if called before VitaClient.configure
-    await VitalHealthKitClient.configure(
+    VitalHealthKitClient.configure(
       .init(
         backgroundDeliveryEnabled: true, logsEnabled: true
       )

--- a/Tests/VitalHealthKitTests/VitalHealthKitReadsTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitReadsTests.swift
@@ -218,7 +218,7 @@ class VitalHealthKitReadsTests: XCTestCase {
       }
       
       let element = vitalStastics.removeFirst()
-      handler(element, nil)
+      handler(.success(element))
     }
     
     debug.isLegacyType = { return true }
@@ -279,7 +279,7 @@ class VitalHealthKitReadsTests: XCTestCase {
       
       dateRanges.append(range)
       let element = vitalStastics.removeFirst()
-      handler(element, nil)
+      handler(.success(element))
     }
     
     debug.isLegacyType = { return false }


### PR DESCRIPTION
* Stop using the `separateBySource` option, so HKStatisticsCollectionQuery would merge all sources and produce one set of statistics only

    * Currently, with `separateBySource`, HealthKit computes one set of statistics individually for each source that has samples within the specified time interval. So if there are 5 sources, we will forward to the backend 5 sets of statistics that are overlapping within the same time frame. This is not the semantic we want; what we want is to report a timeseries per sample type that would resemble the numbers shown by the Apple Health app, which are numbers merged by HealthKit from all sources based on the user's source priority preference.

    * This is crucial for matching statistics reported in the Apple Health app, specifically for certain sample types that are more likely to have multiple active sources (iPhone fitness tracking + Apple Watch, for instance).

    * Individual statistic points are still tagged with sources — We now determine the sources using a subsequent `HKSourceQuery` using the same sample predicate.


* Dropped the `.strictStartDate` option on the statistics collection query predicate. This allows any samples that cross the start date to also contribute to the first time statistics bucket. Note that the sum value contribution of these samples are not in full — they are all weighed on how much time the sample "spent" in the bucket.