### PR TITLE
[VIT-2638] Activity day summaries.

### DIFF
--- a/Sources/VitalCore/Calendar/GregorianCalendar.swift
+++ b/Sources/VitalCore/Calendar/GregorianCalendar.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+public struct GregorianCalendar {
+  public static let utc = GregorianCalendar(timeZone: TimeZone(secondsFromGMT: 0)!)
+
+  let base: Calendar
+
+  public init(timeZone: TimeZone) {
+    var base = Calendar(identifier: .gregorian)
+    base.timeZone = timeZone
+    self.base = base
+  }
+
+  /// End inclusive
+  public func enumerate(_ lowerBound: FloatingDate, _ upperBound: FloatingDate) -> [FloatingDate] {
+    guard lowerBound != upperBound else {
+      // range.lowerBound == range.upperBound
+      return [lowerBound]
+    }
+
+    let endTime = startOfDay(upperBound)
+    var startTime = startOfDay(lowerBound)
+    precondition(startTime < endTime)
+
+    var results = [FloatingDate]()
+
+    while startTime <= endTime {
+      results.append(self.floatingDate(of: startTime))
+
+      guard let nextStartOfDay = base.date(byAdding: .day, value: 1, to: startTime) else {
+        Self.invariantViolation()
+      }
+      startTime = nextStartOfDay
+    }
+
+    return results
+  }
+
+  public func floatingDate(of date: Date) -> FloatingDate {
+    let components = base.dateComponents([.year, .month, .day], from: date)
+    guard let year = components.year, let month = components.month, let day = components.day else {
+      Self.invariantViolation()
+    }
+    return FloatingDate(year: year, month: month, day: day)
+  }
+
+  public func startOfDay(_ date: FloatingDate) -> Date {
+    guard let startOfDay = base.date(from: date.dateComponents()) else {
+      Self.invariantViolation()
+    }
+    return startOfDay
+  }
+
+  public func offset(_ date: FloatingDate, byDays days: Int) -> FloatingDate {
+    guard let newStartOfDay = base.date(byAdding: .day, value: days, to: startOfDay(date)) else {
+      Self.invariantViolation()
+    }
+
+    return floatingDate(of: newStartOfDay)
+  }
+
+  static func invariantViolation(file: StaticString = #file, line: UInt = #line) -> Never {
+    fatalError("This is not expected to happen with Gregorian calendar.", file: file, line: line)
+  }
+}
+
+extension GregorianCalendar {
+  public struct FloatingDate: Hashable, Codable, LosslessStringConvertible {
+    private static let utcFormatter: ISO8601DateFormatter = {
+      let formatter = ISO8601DateFormatter()
+      formatter.formatOptions = [.withFullDate, .withColonSeparatorInTime]
+      formatter.timeZone = TimeZone(secondsFromGMT: 0)
+      return formatter
+    }()
+
+    public let year: Int
+    public let month: Int
+    public let day: Int
+
+    public var description: String {
+      let startOfDay = GregorianCalendar.utc.startOfDay(self)
+      return Self.utcFormatter.string(from: startOfDay)
+    }
+
+    public init?(_ description: String) {
+      guard let date = Self.utcFormatter.date(from: description) else {
+        return nil
+      }
+
+      self = GregorianCalendar.utc.floatingDate(of: date)
+    }
+
+    public init(year: Int, month: Int, day: Int) {
+      self.year = year
+      self.month = month
+      self.day = day
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      let rawValue = try container.decode(String.self)
+
+      guard let date = Self(rawValue) else {
+        throw DecodingError.dataCorrupted(
+          .init(
+            codingPath: container.codingPath,
+            debugDescription: "Unrecognized date format: \(rawValue)"
+          )
+        )
+      }
+
+      self = date
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+      try container.encode(description)
+    }
+
+    public func dateComponents() -> DateComponents {
+      DateComponents(year: year, month: month, day: day)
+    }
+  }
+}

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/ActivityPatch.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/ActivityPatch.swift
@@ -11,7 +11,7 @@ public struct ActivityPatch: Equatable, Encodable {
     public var vo2Max: [QuantitySample] = []
 
     public var isNotEmpty: Bool {
-      daySummary != nil || !activeEnergyBurned.isEmpty ||
+      (daySummary.map(\.isNotEmpty) ?? false) || !activeEnergyBurned.isEmpty ||
       !basalEnergyBurned.isEmpty || !basalEnergyBurned.isEmpty ||
       !steps.isEmpty || !floorsClimbed.isEmpty ||
       !distanceWalkingRunning.isEmpty || !vo2Max.isEmpty

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/ActivityPatch.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/ActivityPatch.swift
@@ -2,14 +2,23 @@ import Foundation
 
 public struct ActivityPatch: Equatable, Encodable {
   public struct Activity: Equatable, Encodable {
+    public var daySummary: DaySummary? = nil
     public var activeEnergyBurned: [QuantitySample] = []
     public var basalEnergyBurned: [QuantitySample] = []
     public var steps: [QuantitySample] = []
     public var floorsClimbed: [QuantitySample] = []
     public var distanceWalkingRunning: [QuantitySample] = []
     public var vo2Max: [QuantitySample] = []
-    
+
+    public var isNotEmpty: Bool {
+      daySummary != nil || !activeEnergyBurned.isEmpty ||
+      !basalEnergyBurned.isEmpty || !basalEnergyBurned.isEmpty ||
+      !steps.isEmpty || !floorsClimbed.isEmpty ||
+      !distanceWalkingRunning.isEmpty || !vo2Max.isEmpty
+    }
+
     public init(
+      daySummary: DaySummary? = nil,
       activeEnergyBurned: [QuantitySample] = [],
       basalEnergyBurned: [QuantitySample] = [],
       steps: [QuantitySample] = [],
@@ -17,6 +26,7 @@ public struct ActivityPatch: Equatable, Encodable {
       distanceWalkingRunning: [QuantitySample] = [],
       vo2Max: [QuantitySample] = []
     ) {
+      self.daySummary = daySummary
       self.activeEnergyBurned = activeEnergyBurned
       self.basalEnergyBurned = basalEnergyBurned
       self.steps = steps
@@ -25,8 +35,47 @@ public struct ActivityPatch: Equatable, Encodable {
       self.vo2Max = vo2Max
     }
   }
+
+  public struct DaySummary: Equatable, Encodable {
+    public let calendarDate: GregorianCalendar.FloatingDate
+
+    public var activeEnergyBurnedSum: Double?
+    public var basalEnergyBurnedSum: Double?
+    public var stepsSum: Int?
+    public var floorsClimbedSum: Int?
+    public var distanceWalkingRunningSum: Double?
+    public var vo2Max: Double?
+
+    public var low: Double?
+    public var medium: Double?
+    public var high: Double?
+
+    public var isNotEmpty: Bool {
+      activeEnergyBurnedSum != nil || basalEnergyBurnedSum != nil ||
+      stepsSum != nil || floorsClimbedSum != nil ||
+      distanceWalkingRunningSum != nil || vo2Max != nil ||
+      low != nil || medium != nil || high != nil
+    }
+
+    public init(calendarDate: GregorianCalendar.FloatingDate, activeEnergyBurnedSum: Double? = nil, basalEnergyBurnedSum: Double? = nil, stepsSum: Int? = nil, floorsClimbedSum: Int? = nil, distanceWalkingRunningSum: Double? = nil, vo2Max: Double? = nil, low: Double? = nil, medium: Double? = nil, high: Double? = nil) {
+      self.calendarDate = calendarDate
+      self.activeEnergyBurnedSum = activeEnergyBurnedSum
+      self.basalEnergyBurnedSum = basalEnergyBurnedSum
+      self.stepsSum = stepsSum
+      self.floorsClimbedSum = floorsClimbedSum
+      self.distanceWalkingRunningSum = distanceWalkingRunningSum
+      self.vo2Max = vo2Max
+      self.low = low
+      self.medium = medium
+      self.high = high
+    }
+  }
   
   public let activities: [Activity]
+
+  public var isNotEmpty: Bool {
+    activities.contains { $0.isNotEmpty }
+  }
   
   public init(activities: [Activity]) {
     self.activities = activities

--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os.log
 
-let sdk_version = "0.7.5"
+let sdk_version = "0.9.0"
 
 struct Credentials: Equatable, Hashable {
   let apiKey: String

--- a/Sources/VitalCore/Get/Source/APIClient.swift
+++ b/Sources/VitalCore/Get/Source/APIClient.swift
@@ -347,6 +347,7 @@ actor APIClient {
     if let body = request.body {
       let encoder = delegate.client(self, encoderForRequest: request) ?? self.encoder
       urlRequest.httpBody = try await encode(body, using: encoder)
+
       if urlRequest.value(forHTTPHeaderField: "Content-Type") == nil &&
           session.configuration.httpAdditionalHeaders?["Content-Type"] == nil {
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -228,8 +228,6 @@ struct StatisticsQueryDependencies {
 
   var key: (HKQuantityType) -> String
 
-  var lastComputedDaySummary: () -> Date?
-
   static var debug: StatisticsQueryDependencies {
     return .init { _, startDate, endDate, handler in
       fatalError()
@@ -246,8 +244,6 @@ struct StatisticsQueryDependencies {
     } storedDate: { _ in
       fatalError()
     } key: { _ in
-      fatalError()
-    } lastComputedDaySummary: {
       fatalError()
     }
   }
@@ -384,8 +380,6 @@ struct StatisticsQueryDependencies {
       
     } key: { type in
       return String(describing: type.self)
-    } lastComputedDaySummary: {
-      return vitalStorage.read(key: VitalHealthKitStorage.daySummaryKey)?.date
     }
   }
 }

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -9,8 +9,18 @@ typealias SeriesSampleHandler = (HKQuantitySeriesSampleQuery, HKQuantity?, DateI
 
 typealias StatisticsHandler = (HKStatisticsCollectionQuery, HKStatisticsCollection?, Error?) -> Void
 
-typealias StatisticsResultHandler = (Result<[VitalStatistics], Error>) -> Void
+typealias HourlyStatisticsResultHandler = (Result<[VitalStatistics], Error>) -> Void
 
+struct VitalStatisticsError: Error {
+  let statistics: HKStatistics
+
+  var description: String {
+    let formatter = ISO8601DateFormatter()
+    let start = formatter.string(from: statistics.startDate)
+    let end = formatter.string(from: statistics.endDate)
+    return "Failed to convert HKStatistics for \(statistics.quantityType.identifier): \(start) -> \(end)"
+  }
+}
 
 private func read(
   type: HKSampleType,
@@ -42,12 +52,12 @@ private func read(
     
     let dependencies = StatisticsQueryDependencies.live(
       healthKitStore: healthKitStore,
-      vitalStorage: vitalStorage,
-      type: type
+      vitalStorage: vitalStorage
     )
     
     let payload = try await queryStatisticsSample(
       dependency: dependencies,
+      type: type,
       startDate: startDate,
       endDate: endDate
     )
@@ -183,7 +193,7 @@ func read(
         endDate: endDate
       )
       
-      return (.summary(.activity(payload.activityPatch)), payload.anchors)
+      return (payload.activityPatch.map { .summary(.activity($0)) }, payload.anchors)
       
     case .workout:
       let payload = try await handleWorkouts(
@@ -321,7 +331,7 @@ func handleProfile(
     biologicalSex: biologicalSex,
     dateOfBirth: dateOfBirth,
     height: height,
-    timeZone: TimeZone.autoupdatingCurrent.identifier
+    timeZone: TimeZone.current.identifier
   )
   let id = profile.id
 
@@ -564,8 +574,13 @@ func handleActivity(
   vitalStorage: VitalHealthKitStorage,
   startDate: Date,
   endDate: Date
-) async throws -> (activityPatch: ActivityPatch, anchors: [StoredAnchor]) {
-  
+) async throws -> (activityPatch: ActivityPatch?, anchors: [StoredAnchor]) {
+
+  let dependencies = StatisticsQueryDependencies.live(
+    healthKitStore: healthKitStore,
+    vitalStorage: vitalStorage
+  )
+
   func queryQuantities(
     type: HKSampleType
   ) async throws -> (quantities: [QuantitySample], StoredAnchor?) {
@@ -581,53 +596,57 @@ func handleActivity(
     let quantities: [QuantitySample] = payload.sample.compactMap(QuantitySample.init)
     return (quantities, payload.anchor)
   }
-  
-  func queryStatistics(
+
+  func queryHourlyStatistics(
     type: HKQuantityType
   ) async throws -> (quantities: [QuantitySample], StoredAnchor?) {
-    
-    let dependencies = StatisticsQueryDependencies.live(
-      healthKitStore: healthKitStore,
-      vitalStorage: vitalStorage,
-      type: type
-    )
-    
+
     let payload = try await queryStatisticsSample(
       dependency: dependencies,
+      type: type,
       startDate: startDate,
       endDate: endDate
     )
-        
+
     let quantities: [QuantitySample] = payload.statistics.compactMap { value in
       return QuantitySample(value, type)
     }
-    
+
     return (quantities, payload.anchor)
   }
+
+  // - Day summaries
+
+  let (daySummaries, daySummaryAnchor) = try await queryActivityDaySummaries(
+    dependencies: dependencies,
+    startTime: startDate,
+    endTime: endDate
+  )
+
+  // - Hourly timeseries samples
+  var anchors: [StoredAnchor] = [daySummaryAnchor]
   
-  var anchors: [StoredAnchor] = []
-  
-  let (activeEnergyBurned, activeEnergyBurnedAnchor) = try await queryStatistics(
+  let (activeEnergyBurned, activeEnergyBurnedAnchor) = try await queryHourlyStatistics(
     type: .quantityType(forIdentifier: .activeEnergyBurned)!
   )
   
-  let (basalEnergyBurned, basalEnergyBurnedAnchor) = try await queryStatistics(
+  let (basalEnergyBurned, basalEnergyBurnedAnchor) = try await queryHourlyStatistics(
     type: .quantityType(forIdentifier: .basalEnergyBurned)!
   )
   
-  let (steps, stepsAnchor) = try await queryStatistics(
+  let (steps, stepsAnchor) = try await queryHourlyStatistics(
     type: .quantityType(forIdentifier: .stepCount)!
   )
   
-  let (floorsClimbed, floorsClimbedAnchor) = try await queryStatistics(
+  let (floorsClimbed, floorsClimbedAnchor) = try await queryHourlyStatistics(
     type: .quantityType(forIdentifier: .flightsClimbed)!
   )
   
-  let (distanceWalkingRunning, distanceWalkingRunningAnchor) = try await queryStatistics(
+  let (distanceWalkingRunning, distanceWalkingRunningAnchor) = try await queryHourlyStatistics(
     type: .quantityType(forIdentifier: .distanceWalkingRunning)!
   )
   
-  let (vo2Max, vo2MaxAnchor) = try await queryQuantities(
+  let (vo2Max, vo2MaxAnchor) = try await queryHourlyStatistics(
     type: .quantityType(forIdentifier: .vo2Max)!
   )
   
@@ -637,38 +656,20 @@ func handleActivity(
   anchors.appendOptional(floorsClimbedAnchor)
   anchors.appendOptional(distanceWalkingRunningAnchor)
   anchors.appendOptional(vo2MaxAnchor)
-  
-  let allSamples = Array(
-    [
-      activeEnergyBurned,
-      basalEnergyBurned,
-      steps,
-      floorsClimbed,
-      distanceWalkingRunning,
-      vo2Max
-    ].joined()
+
+  let allDaySummaries = daySummaries.map { ActivityPatch.Activity(daySummary: $0) }
+  let allSamples = ActivityPatch.Activity(
+    activeEnergyBurned: activeEnergyBurned,
+    basalEnergyBurned: basalEnergyBurned,
+    steps: steps,
+    floorsClimbed: floorsClimbed,
+    distanceWalkingRunning: distanceWalkingRunning,
+    vo2Max: vo2Max
   )
+
+  let patch = ActivityPatch(activities: allDaySummaries + [allSamples])
   
-  let allDates: Set<Date> = Set(allSamples.reduce([]) { acc, next in
-    acc + [next.startDate.dayStart]
-  })
-  
-  let activities: [ActivityPatch.Activity] = allDates.map { date in
-    func filter(_ samples: [QuantitySample]) -> [QuantitySample] {
-      samples.filter { $0.startDate.dayStart == date }
-    }
-    
-    return ActivityPatch.Activity(
-      activeEnergyBurned: filter(activeEnergyBurned),
-      basalEnergyBurned: filter(basalEnergyBurned),
-      steps: filter(steps),
-      floorsClimbed: filter(floorsClimbed),
-      distanceWalkingRunning: filter(distanceWalkingRunning),
-      vo2Max: filter(vo2Max)
-    )
-  }
-  
-  return (.init(activities: activities), anchors: anchors)
+  return (patch.isNotEmpty ? patch : nil, anchors: anchors)
 }
 
 func handleWorkouts(
@@ -887,6 +888,7 @@ func calculateIdsForAnchorsAndData(
 /// TODO: To be Removed
 private func populateAnchorsForStatisticalQuery(
   dependency: StatisticsQueryDependencies,
+  type: HKQuantityType,
   statisticsQueryStartDate: Date
 ) async throws -> [VitalAnchor] {
     
@@ -895,7 +897,7 @@ private func populateAnchorsForStatisticalQuery(
 
   return try await withCheckedThrowingContinuation { continuation in
     
-    let handler: StatisticsResultHandler = { result in
+    let handler: HourlyStatisticsResultHandler = { result in
       switch result {
       case let .success(statistics):
         let newAnchors = calculateIdsForAnchorsPopulation(
@@ -910,7 +912,7 @@ private func populateAnchorsForStatisticalQuery(
       }
     }
             
-    dependency.executeStatisticalQuery(startDate, endDate, handler)
+    dependency.executeHourlyStatisticalQuery(type, startDate, endDate, handler)
   }
 }
 
@@ -938,17 +940,18 @@ private func populateAnchorsForStatisticalQuery(
 ///
 func queryStatisticsSample(
   dependency: StatisticsQueryDependencies,
+  type: HKQuantityType,
   startDate: Date,
   endDate: Date
 ) async throws -> (statistics: [VitalStatistics], anchor: StoredAnchor) {
   
   let vitalAnchors: [VitalAnchor]
   
-  let newStartDate = dependency.storedDate() ?? startDate
+  let newStartDate = dependency.storedDate(type) ?? startDate
   let newEndDate = endDate.nextHour
   
-  let isFirstTimeSycingType = dependency.isFirstTimeSycingType()
-  let isLegacyType = dependency.isLegacyType()
+  let isFirstTimeSycingType = dependency.isFirstTimeSycingType(type)
+  let isLegacyType = dependency.isLegacyType(type)
   
     
   ///  TODO: Remove this in the near future
@@ -957,10 +960,11 @@ func queryStatisticsSample(
     /// We will fill up 21 days worth of anchors
     vitalAnchors = try await populateAnchorsForStatisticalQuery(
       dependency: dependency,
+      type: type,
       statisticsQueryStartDate: newStartDate
     )
   } else {
-    vitalAnchors = dependency.vitalAnchorsForType()
+    vitalAnchors = dependency.vitalAnchorsForType(type)
   }
   ///
   /// </TO BE REMOVED>
@@ -984,18 +988,18 @@ func queryStatisticsSample(
   let statisticsEndDate = newEndDate.nextHour
   
   
-  let samples: [HKSample] = try await dependency.executeSampleQuery(statisticsStarDate, statisticsEndDate)
+  let samples: [HKSample] = try await dependency.executeSampleQuery(type, statisticsStarDate, statisticsEndDate)
   
   
   return try await withCheckedThrowingContinuation { continuation in
     
-    let handler: StatisticsResultHandler = { result in
+    let handler: HourlyStatisticsResultHandler = { result in
       switch result {
       case let .success(statistics):
         let payload = calculateIdsForAnchorsAndData(
           vitalStatistics: statistics,
           existingAnchors: vitalAnchors,
-          key: dependency.key(),
+          key: dependency.key(type),
           date: newEndDate
         )
 
@@ -1007,7 +1011,7 @@ func queryStatisticsSample(
       }
     }
     
-    dependency.executeStatisticalQuery(statisticsStarDate, statisticsEndDate, handler)
+    dependency.executeHourlyStatisticalQuery(type, statisticsStarDate, statisticsEndDate, handler)
   }
 }
 
@@ -1055,6 +1059,87 @@ func enrichWithDates(samples: [HKSample], statistics: [VitalStatistics]) -> [Vit
     
     return copy
   }
+}
+
+/// We compute one summary per quantity type for the calendar day in the
+/// **CURRENT DEVICE TIME ZONE**. After all, a (floating) day cannot be
+/// projected into into UTC time without a time zone, and the user intuition is
+/// to see numbers and time that align to their perception of time.
+///
+/// (where the device time zone is the closest approximation)
+///
+/// This is different from the typical hourly timeseries samples gathering process, which
+/// works with `HKStatisticalCollectionQuery` solely in UTC time (`vitalCalendar`).
+/// Hour granularity is time zone agnostic, and the resulting hourly samples can be reinterpreted into all
+/// time zones pretty easily and consistently.
+func queryActivityDaySummaries(
+  dependencies: StatisticsQueryDependencies,
+  startTime: Date,
+  endTime: Date
+) async throws -> ([ActivityPatch.DaySummary], StoredAnchor) {
+  let calendar = GregorianCalendar(timeZone: .current)
+
+  let startTime = dependencies.lastComputedDaySummary() ?? startTime
+
+  let datesToCompute = calendar.enumerate(
+    // System wall time can go backwards. Cap the start time just in case.
+    calendar.floatingDate(of: min(startTime, endTime)),
+    calendar.floatingDate(of: endTime)
+  )
+
+  logger?.info("[Day Summary] lastComputed = \(startTime) now = \(endTime) datesToCompute = \(datesToCompute)")
+
+  let daySummaries = try await withThrowingTaskGroup(of: ActivityPatch.DaySummary.self) { group -> [ActivityPatch.DaySummary] in
+    for date in datesToCompute {
+      group.addTask {
+        async let activeEnergyBurnedSum = dependencies.executeDaySummaryQuery(
+          HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned)!,
+          date,
+          calendar
+        )
+        async let basalEnergyBurnedSum = dependencies.executeDaySummaryQuery(
+          HKQuantityType.quantityType(forIdentifier: .basalEnergyBurned)!,
+          date,
+          calendar
+        )
+        async let stepsSum = dependencies.executeDaySummaryQuery(
+          HKQuantityType.quantityType(forIdentifier: .stepCount)!,
+          date,
+          calendar
+        )
+        async let floorsClimbedSum = dependencies.executeDaySummaryQuery(
+          HKQuantityType.quantityType(forIdentifier: .flightsClimbed)!,
+          date,
+          calendar
+        )
+        async let distanceWalkingRunningSum = dependencies.executeDaySummaryQuery(
+          HKQuantityType.quantityType(forIdentifier: .distanceWalkingRunning)!,
+          date,
+          calendar
+        )
+
+        return await ActivityPatch.DaySummary(
+          calendarDate: date,
+          activeEnergyBurnedSum: try activeEnergyBurnedSum?.value,
+          basalEnergyBurnedSum: try basalEnergyBurnedSum?.value,
+          stepsSum: try (stepsSum?.value).map(Int.init),
+          floorsClimbedSum: try (floorsClimbedSum?.value).map(Int.init),
+          distanceWalkingRunningSum: try distanceWalkingRunningSum?.value
+        )
+      }
+    }
+
+    return try await group.reduce(into: []) { $0.append($1) }
+  }
+
+  let newAnchor = StoredAnchor(
+    key: VitalHealthKitStorage.daySummaryKey,
+    anchor: nil,
+    date: endTime,
+    vitalAnchors: nil
+  )
+
+  return (daySummaries.filter(\.isNotEmpty), newAnchor)
 }
 
 func querySample(

--- a/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
@@ -335,6 +335,52 @@ extension HKSampleType {
         fatalError("\(String(describing: self)) type not supported)")
     }
   }
+
+  var idealStatisticalQueryOptions: HKStatisticsOptions {
+    guard let quantityType = self as? HKQuantityType else {
+      fatalError("Only quantity types can work with HKStatisticalQuery.")
+    }
+
+    switch quantityType.aggregationStyle {
+    case .cumulative:
+      // We always want sum for cumulative quantity types.
+      return [.cumulativeSum]
+
+    case .discreteArithmetic:
+      // Defaults to most recent reading.
+      return [.mostRecent]
+
+    case .discreteTemporallyWeighted, .discreteEquivalentContinuousLevel:
+      // Not supported.
+      return []
+
+    @unknown default:
+      return []
+    }
+  }
+
+  func idealStatisticalQuantity(from statistics: HKStatistics) -> HKQuantity? {
+    guard let quantityType = self as? HKQuantityType else {
+      fatalError("Only quantity types can work with HKStatisticalQuery.")
+    }
+
+    switch quantityType.aggregationStyle {
+    case .cumulative:
+      // We always want sum for cumulative quantity types.
+      return statistics.sumQuantity()
+
+    case .discreteArithmetic:
+      // Defaults to most recent reading.
+      return statistics.mostRecentQuantity()
+
+    case .discreteTemporallyWeighted, .discreteEquivalentContinuousLevel:
+      // Not supported.
+      return nil
+
+    @unknown default:
+      return nil
+    }
+  }
 }
 
 extension ProfilePatch.BiologicalSex {

--- a/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
+++ b/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
@@ -3,8 +3,6 @@ import VitalCore
 
 class VitalHealthKitStorage {
 
-  static let daySummaryKey = "vital_activity_day_summary"
-
   private let anchorPrefix = "vital_anchor_"
   private let anchorsPrefix = "vital_anchors_"
 
@@ -99,7 +97,8 @@ class VitalHealthKitStorage {
 struct StoredAnchor {
   var key: String
   var anchor: HKQueryAnchor?
-  /// To be deprecated (1.0)
+
+  /// Used by the day summary process to determine when a summary was last computed.
   var date : Date?
   
   /// New approach (2.0)

--- a/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
+++ b/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
@@ -2,7 +2,9 @@ import HealthKit
 import VitalCore
 
 class VitalHealthKitStorage {
-  
+
+  static let daySummaryKey = "vital_activity_day_summary"
+
   private let anchorPrefix = "vital_anchor_"
   private let anchorsPrefix = "vital_anchors_"
 

--- a/Sources/VitalHealthKit/HealthKit/Storage/VitalStatistics.swift
+++ b/Sources/VitalHealthKit/HealthKit/Storage/VitalStatistics.swift
@@ -29,12 +29,15 @@ struct VitalStatistics {
     self.sources = sources
   }
     
-  init?(statistics: HKStatistics, type: HKQuantityType, sources: [String]) {
-    guard let sum = statistics.sumQuantity() else {
-      return nil
-    }
+  init(statistics: HKStatistics, type: HKQuantityType, sources: [String]) throws {
+    let unit = type.toHealthKitUnits
+
+    guard
+      type.is(compatibleWith: unit),
+      let quantity = type.idealStatisticalQuantity(from: statistics)
+    else { throw VitalStatisticsError(statistics: statistics) }
     
-    let value = sum.doubleValue(for: type.toHealthKitUnits)
+    let value = quantity.doubleValue(for: unit)
     self.init(
       value: value,
       type: String(describing: type),


### PR DESCRIPTION
### Activity Day Summary

An activity day summary is aggregated from 5 sample types, containing 5 sums for a specific calendar day in the device TZ.

The SDK now computes day summaries as part of `handleActivity(...)`, specifically:

1. ~~A new `StoredAnchor` is dedicated to track when the last activity day summary was computed.~~

2. Given the last computed time and the current wall time, we enumerate all the floating dates that lie within this time interval with respect to the device TZ.

     * e.g.1., if both last computed and current wall time both lie in `2023-01-02` in the device TZ, only `2023-01-02` would be enumerated.
     * e.g.1., if last computed lies in `2022-12-31` in the device TZ, and that of the current wall time was `2023-01-02`, `2022-12-31`, `2023-01-01` and `2023-01-02` would be enumerated.
     * The number of dates being enumerated are ultimately (indirectly) limited by the number of backfill days settings, just like anything else.

3. For each enumerated floating date, a day summary is computed with respect to the date and the current device TZ.

4. Resulting day summaries are packed into the same `ActivityPatch`, alongside timeseries samples we gathered.

### ActivityPatch request packing

The SDK has stopped groups timeseries samples day by day into different `ActivityPatch.Activity`, since the backend no longer requires the grouping with the introduction of day summaries.

### Statistical Query tweaks

* The SDK now explicitly catches `HKError.Code.errorNoData`, which can be reported by both HKStatisticsCollectionQuery and HKStatisticsQuery when no sample is matched at all by the predicate.

* `HKQuantityType` is now passed in as method call argument, rather than as a constant per `StatisticsQueryDependencies` instance, consequentially requiring recreating instances for different quantity sample types.

### Bumping the reported SDK version
The SDK now declares version 0.9.0 to our API.

### New utility: `GregorianCalendar` in VitalCore
`GregorianCalendar` provides a simplified interface for (currently) floating date level maths based on the Gregorian calendar.

It is a wrapper around `Foundation.Calendar`, abstracting away invariant/non-nil checks that would otherwise be required when working with more generic `Foundation.Calendar` designed to support alternative calendars.

`GregorianCalendar.FloatingDate` is a new scalar type that can represent a floating date (`YYYY-mm-dd`) not affixed to any time basis or time zone. It is `Codable` to/from ISO8601 date-only string rep. as well.