### PR TITLE
[WIP] Optimize VitalStatistics enrichment

### DIFF
--- a/Sources/VitalHealthKit/Extensions/Date.swift
+++ b/Sources/VitalHealthKit/Extensions/Date.swift
@@ -25,8 +25,7 @@ extension Date {
   }
   
   var dayStart: Date {
-    let date = vitalCalendar.date(bySettingHour: 0, minute: 0, second: 0, of: self)!
-    return date
+    return vitalCalendar.startOfDay(for: self)
   }
   
   var dayEnd: Date {

--- a/Sources/VitalHealthKit/HealthKit/Storage/VitalStatistics.swift
+++ b/Sources/VitalHealthKit/HealthKit/Storage/VitalStatistics.swift
@@ -2,7 +2,7 @@ import HealthKit
 
 struct VitalStatistics {
   var value: Double
-  var type: String
+  var type: HKQuantityType
   var startDate: Date
   var endDate: Date
   
@@ -17,7 +17,7 @@ struct VitalStatistics {
   
   init(
     value: Double,
-    type: String,
+    type: HKQuantityType,
     startDate: Date,
     endDate: Date,
     sources: [String]
@@ -37,10 +37,17 @@ struct VitalStatistics {
     let value = sum.doubleValue(for: type.toHealthKitUnits)
     self.init(
       value: value,
-      type: String(describing: type),
+      type: type,
       startDate: statistics.startDate,
       endDate: statistics.endDate,
       sources: sources
     )
+  }
+
+  func withSampleDates(first: Date, last: Date) -> Self {
+    var copy = self
+    copy.firstSampleDate = first
+    copy.lastSampleDate = last
+    return copy
   }
 }

--- a/Tests/VitalHealthKitTests/VitalHealthKitAnchorTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitAnchorTests.swift
@@ -7,7 +7,7 @@ import HealthKit
 class VitalHealthKitAnchorTests: XCTestCase {
     
   func testAnchorsPopulation() {
-    let type = "type"
+    let type = HKQuantityType.quantityType(forIdentifier: .stepCount)!
     let input: [VitalStatistics] = [
       .init(value: 1, type: type, startDate: Date(), endDate: Date(), sources: []),
       .init(value: 2, type: type, startDate: Date(), endDate: Date(), sources: []),
@@ -25,7 +25,7 @@ class VitalHealthKitAnchorTests: XCTestCase {
   }
   
   func testAnchorsAndData() {
-    let type = "type"
+    let type = HKQuantityType.quantityType(forIdentifier: .stepCount)!
     let key = "key"
     let existing: [VitalAnchor] = [
       .init(id: "1"),
@@ -47,7 +47,7 @@ class VitalHealthKitAnchorTests: XCTestCase {
   }
   
   func testAnchorsAndDataNoExisting() {
-    let type = "type"
+    let type = HKQuantityType.quantityType(forIdentifier: .stepCount)!
     let key = "key"
     let existing: [VitalAnchor] = [
     ]

--- a/Tests/VitalHealthKitTests/VitalHealthKitReadsTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitReadsTests.swift
@@ -181,15 +181,16 @@ class VitalHealthKitReadsTests: XCTestCase {
   }
   
   func testStatisticalReadingForLegacyUser() async throws {
+    let type = HKQuantityType.quantityType(forIdentifier: .stepCount)!
     let key = "key"
     var vitalStastics: [[VitalStatistics]] = [
       [
-        .init(value: 10, type: key, startDate: Date(), endDate: Date(), sources: []),
-        .init(value: 20, type: key, startDate: Date(), endDate: Date(), sources: []),
-        .init(value: 30, type: key, startDate: Date(), endDate: Date(), sources: [])
+        .init(value: 10, type: type, startDate: Date(), endDate: Date(), sources: []),
+        .init(value: 20, type: type, startDate: Date(), endDate: Date(), sources: []),
+        .init(value: 30, type: type, startDate: Date(), endDate: Date(), sources: [])
       ],
       [
-        .init(value: 5, type: key, startDate: Date(), endDate: Date(), sources: [])
+        .init(value: 5, type: type, startDate: Date(), endDate: Date(), sources: [])
       ]
     ]
     
@@ -198,10 +199,6 @@ class VitalHealthKitReadsTests: XCTestCase {
     let (startDate, endDate) = (Date.dateAgo(date, days: 30), date)
 
     var dateRanges: [ClosedRange<Date>] = []
-    
-    debug.executeSampleQuery = { _, _ in
-      return []
-    }
     
     debug.executeStatisticalQuery = { queryStartDate, queryEndDate, handler in
       let range = queryStartDate ... queryEndDate
@@ -219,6 +216,10 @@ class VitalHealthKitReadsTests: XCTestCase {
       
       let element = vitalStastics.removeFirst()
       handler(.success(element))
+    }
+
+    debug.getFirstAndLastSampleTime = { type, start, end in
+      return nil
     }
     
     debug.isLegacyType = { return true }
@@ -252,10 +253,11 @@ class VitalHealthKitReadsTests: XCTestCase {
   }
   
   func testStatisticalReadingForNewUser() async throws {
+    let type = HKQuantityType.quantityType(forIdentifier: .stepCount)!
     let key = "key"
     var vitalStastics: [[VitalStatistics]] = [
       [
-        .init(value: 5, type: key, startDate: Date(), endDate: Date(), sources: [])
+        .init(value: 5, type: type, startDate: Date(), endDate: Date(), sources: [])
       ]
     ]
     
@@ -265,9 +267,9 @@ class VitalHealthKitReadsTests: XCTestCase {
     let (startDate, endDate) = (Date.dateAgo(date, days: 30), date)
 
     var dateRanges: [ClosedRange<Date>] = []
-    
-    debug.executeSampleQuery = { _, _ in
-      return []
+
+    debug.getFirstAndLastSampleTime = { type, start, end in
+      return nil
     }
     
     debug.executeStatisticalQuery = { queryStartDate, queryEndDate, handler in


### PR DESCRIPTION
For each hourly statistics point, ask `HKSampleQuery` for the first and the last sample that falls in the hour time interval. Then use their `startDate` to populate `firstSampleDate` and `lastSampleDate`.

This reduces the time complexity from O(n<sup>2</sup>) to O(n*log(n)), assuming HealthKit does internally fulfil time range predicates using indexes. It also avoids the need to dump all matching samples into memory.


## Profiling result
120 days backfill, 6.8x speedup

### before
![Screenshot 2023-03-16 at 18 19 33](https://user-images.githubusercontent.com/11806295/225716415-4b47ab8f-5f14-4c04-915a-885aff062eb6.png)

1m 49s
3 low memory warnings + over CPU budget

### after
![Screenshot 2023-03-16 at 18 19 54](https://user-images.githubusercontent.com/11806295/225716417-2833fd16-c03c-4b18-9cc5-0aa00fc38af5.png)

16s