### PR TITLE
[VIT-2666] Workaround a HKStatCollectionQuery quirk

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -272,6 +272,8 @@ struct StatisticsQueryDependencies {
         anchorDate: startDate,
         intervalComponents: .init(hour: 1)
       )
+
+      let queryInterval = startDate ... endDate
       
       let queryHandler: StatisticsHandler = { query, statistics, error in
         healthKitStore.stop(query)
@@ -286,7 +288,21 @@ struct StatisticsQueryDependencies {
         // would have been matched by the HKStatisticsCollectionQuery.
         let sourceQuery = HKSourceQuery(sampleType: type, samplePredicate: predicate) { _, sources, _ in
           let sources = sources?.map { $0.bundleIdentifier } ?? []
-          let values: [HKStatistics] = statistics.statistics()
+          let values: [HKStatistics] = statistics.statistics().filter { entry in
+            // We perform a HKStatisticsCollectionQuery w/o strictStartDate and strictEndDate in
+            // order to have aggregates matching numbers in the Health app.
+            //
+            // However, a caveat is that HealthKit can often return incomplete statistics point
+            // outside the query interval we specified. While including samples astriding the
+            // bounds would desirably contribute to stat points we are interested in, as a byproduct,
+            // of the bucketing process (in our case, hourly buckets), HealthKit would also create
+            // stat points from the unwanted portion of these samples.
+            //
+            // These unwanted stat points must be explicitly discarded, since they are not backed by
+            // the complete set of samples within their representing time interval (as they are
+            // rightfully excluded by the query interval we specified).
+            queryInterval.contains(entry.startDate) && queryInterval.contains(entry.endDate)
+          }
 
           let vitalStatistics = values.compactMap { statistics in
             VitalStatistics(statistics: statistics, type: type, sources: sources)


### PR DESCRIPTION
We perform a HKStatisticsCollectionQuery w/o strictStartDate and strictEndDate in order to have aggregates matching numbers in the Health app.

However, a caveat is that HealthKit can often return incomplete statistics point outside the query interval we specified. While including samples astriding the bounds would desirably contribute to stat points we are interested in, as a byproduct of the bucketing process (in our case, hourly buckets), HealthKit would also create stat points from the unwanted portion of these samples.

These unwanted stat points must be explicitly discarded, since they are not backed by the complete set of samples within their representing time interval (as they are rightfully excluded by the query interval we specified).



### explanation


say we have five step samples:
- 2022-01-02 13:24-14:36, 80 steps
- 2022-01-02 13:57-14:02 (5 minutes), 100 steps
- 2022-01-02 14:30-14:42, 200 steps
- 2022-01-02 14:55-15:07 (12 minutes), 120 steps
- 2022-01-02 15:44-15:51, 36 steps

when one performs HKStatisticsCollectionQuery with interval = {hour: 1} and a range of 2022-01-02 **14:00-15:00** (so just statistics for 2 o'clock), this would result in **3** rather than 1 statistics points:

- 2022-01-02 13:00-14:00
    * sum = 3/5 min * 100 steps = 60 steps
- 2022-01-02 14:00-15:00
    * sum = 2/5 min * 100 steps + 200 steps + 5/12 min * 120 steps = 290 steps
- 2022-01-02 15:00-16:00
    * sum = 7/12 min * 120 steps = 70 steps

The first and last stat points are obviously incorrect, or more accurately speaking, incomplete.

But HKStatisticsCollectionQuery also technically does nothing wrong — the sample predicate applies only to the initial samples query stage; it doesn't apply to the statistics computation.

* It did get all the samples partially or fully lying in 14:00-15:00
* It then did bucket them by the hour
* It then did split any sample crossing multiple buckets based on duration
* It then did its source order resolution thing.
* It did finally compute a sum for each hourly bucket.