### PR TITLE
Tweak CI and include example app build

### DIFF
--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -3,11 +3,8 @@ name: "Run CI"
 on: [push]
 
 jobs:
-  build-sdks:
+  test-sdks:
     runs-on: macos-12
-    strategy:
-      matrix:
-        scheme: ["VitalDevices"]
     steps:
       - name: Xcode Select
         run: sudo xcode-select -s /Applications/Xcode_14.1.app
@@ -15,22 +12,7 @@ jobs:
         uses: actions/checkout@master
       - name: Build
         run: |
-          xcodebuild clean build -scheme "${scheme}" -destination 'generic/platform=iOS'
-        env:
-          scheme: ${{ matrix.scheme }}
-
-  test-sdks:
-    runs-on: macos-12
-    strategy:
-      matrix:
-        scheme: ["VitalHealthKit", "VitalCore"]
-    steps:
-      - name: Xcode Select
-        run: sudo xcode-select -s /Applications/Xcode_14.1.app
-      - name: Checkout
-        uses: actions/checkout@master
-      - name: Test
-        run: |
-          xcodebuild clean test -scheme "${scheme}" -destination platform=iOS\ Simulator,OS=16.1,name=iPhone\ 13
-        env:
-          scheme: ${{ matrix.scheme }}
+          xcodebuild test -scheme VitalCore -destination platform=iOS\ Simulator,OS=16.1,name=iPhone\ 13
+          xcodebuild build -scheme VitalDevices -destination 'generic/platform=iOS'
+          xcodebuild test -scheme VitalHealthKit -destination platform=iOS\ Simulator,OS=16.1,name=iPhone\ 13
+          xcodebuild build-for-testing -scheme Example -destination platform=iOS\ Simulator,OS=16.1,name=iPhone\ 13


### PR DESCRIPTION
Merge into one job so repo fetch and build products can be shared.
Build the example app as part of the job.