### PR TITLE
[VIT-2671] Merge Provider and FullProvider types

### DIFF
--- a/Sources/VitalCore/Core/Client/Data Models/Patches/Provider.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/Provider.swift
@@ -1,44 +1,54 @@
 struct ProviderResponse: Equatable, Decodable {
   struct Provider: Equatable, Decodable {
     let name: String
-    let slug: String
+    let slug: VitalCore.Provider.Slug
     let logo: String
   }
   
   let providers: [ProviderResponse.Provider]
 }
 
-public struct FullProvider: Equatable {
+public struct Provider: Equatable {
   public let name: String
-  public let slug: String
+  public let slug: Slug
   public let logo: String
-}
 
-public enum Provider: String, Codable {
-  case beurerBLE = "beurer_ble"
-  case beurer = "beurer_api"
-  case omronBLE = "omron_ble"
-  case accuchekBLE = "accuchek_ble"
-  case contourBLE = "contour_ble"
-  case appleHealthKit = "apple_health_kit"
-  case manual = "manual"
-  case iHealth = "ihealth"
-  case libreBLE = "freestyle_libre_ble"
-  case libre = "freestyle_libre"
-  case oura = "oura"
-  case garmin = "garmin"
-  case fitbit = "fitbit"
-  case whoop = "whoop"
-  case strava = "strava"
-  case renpho = "renpho"
-  case peloton = "peloton"
-  case wahoo = "wahoo"
-  case zwift = "zwift"
-  case eightSleep = "eight_sleep"
-  case withings = "withings"
-  case googleFit = "google_fit"
-  case hammerhead = "hammerhead"
-  case dexcom = "dexcom"
-  case myFitnessPal = "my_fitness_pal"
-  case healthConnect = "health_connect"
+  public struct Slug: Hashable, RawRepresentable, Codable, ExpressibleByStringLiteral {
+    public static let beurerBLE: Self = "beurer_ble"
+    public static let beurer: Self = "beurer_api"
+    public static let omronBLE: Self = "omron_ble"
+    public static let accuchekBLE: Self = "accuchek_ble"
+    public static let contourBLE: Self = "contour_ble"
+    public static let appleHealthKit: Self = "apple_health_kit"
+    public static let manual: Self = "manual"
+    public static let iHealth: Self = "ihealth"
+    public static let libreBLE: Self = "freestyle_libre_ble"
+    public static let libre: Self = "freestyle_libre"
+    public static let oura: Self = "oura"
+    public static let garmin: Self = "garmin"
+    public static let fitbit: Self = "fitbit"
+    public static let whoop: Self = "whoop"
+    public static let strava: Self = "strava"
+    public static let renpho: Self = "renpho"
+    public static let peloton: Self = "peloton"
+    public static let wahoo: Self = "wahoo"
+    public static let zwift: Self = "zwift"
+    public static let eightSleep: Self = "eight_sleep"
+    public static let withings: Self = "withings"
+    public static let googleFit: Self = "google_fit"
+    public static let hammerhead: Self = "hammerhead"
+    public static let dexcom: Self = "dexcom"
+    public static let myFitnessPal: Self = "my_fitness_pal"
+    public static let healthConnect: Self = "health_connect"
+
+    public let rawValue: String
+
+    public init(stringLiteral value: StringLiteralType) {
+      self.init(rawValue: value)
+    }
+
+    public init(rawValue: String) {
+      self.rawValue = rawValue
+    }
+  }
 }

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/Provider.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/Provider.swift
@@ -13,42 +13,97 @@ public struct Provider: Equatable {
   public let slug: Slug
   public let logo: String
 
-  public struct Slug: Hashable, RawRepresentable, Codable, ExpressibleByStringLiteral {
-    public static let beurerBLE: Self = "beurer_ble"
-    public static let beurer: Self = "beurer_api"
-    public static let omronBLE: Self = "omron_ble"
-    public static let accuchekBLE: Self = "accuchek_ble"
-    public static let contourBLE: Self = "contour_ble"
-    public static let appleHealthKit: Self = "apple_health_kit"
-    public static let manual: Self = "manual"
-    public static let iHealth: Self = "ihealth"
-    public static let libreBLE: Self = "freestyle_libre_ble"
-    public static let libre: Self = "freestyle_libre"
-    public static let oura: Self = "oura"
-    public static let garmin: Self = "garmin"
-    public static let fitbit: Self = "fitbit"
-    public static let whoop: Self = "whoop"
-    public static let strava: Self = "strava"
-    public static let renpho: Self = "renpho"
-    public static let peloton: Self = "peloton"
-    public static let wahoo: Self = "wahoo"
-    public static let zwift: Self = "zwift"
-    public static let eightSleep: Self = "eight_sleep"
-    public static let withings: Self = "withings"
-    public static let googleFit: Self = "google_fit"
-    public static let hammerhead: Self = "hammerhead"
-    public static let dexcom: Self = "dexcom"
-    public static let myFitnessPal: Self = "my_fitness_pal"
-    public static let healthConnect: Self = "health_connect"
+  public enum Slug: Hashable, Codable, RawRepresentable {
+    case beurerBLE
+    case beurer
+    case omronBLE
+    case accuchekBLE
+    case contourBLE
+    case appleHealthKit
+    case manual
+    case iHealth
+    case libreBLE
+    case libre
+    case oura
+    case garmin
+    case fitbit
+    case whoop
+    case strava
+    case renpho
+    case peloton
+    case wahoo
+    case zwift
+    case eightSleep
+    case withings
+    case googleFit
+    case hammerhead
+    case dexcom
+    case myFitnessPal
+    case healthConnect
+    case unknown(String)
 
-    public let rawValue: String
-
-    public init(stringLiteral value: StringLiteralType) {
-      self.init(rawValue: value)
+    public var rawValue: String {
+      switch self {
+      case .beurerBLE: return "beurer_ble"
+      case .beurer: return "beurer_api"
+      case .omronBLE: return "omron_ble"
+      case .accuchekBLE: return "accuchek_ble"
+      case .contourBLE: return "contour_ble"
+      case .appleHealthKit: return "apple_health_kit"
+      case .manual: return "manual"
+      case .iHealth: return "ihealth"
+      case .libreBLE: return "freestyle_libre_ble"
+      case .libre: return "freestyle_libre"
+      case .oura: return "oura"
+      case .garmin: return "garmin"
+      case .fitbit: return "fitbit"
+      case .whoop: return "whoop"
+      case .strava: return "strava"
+      case .renpho: return "renpho"
+      case .peloton: return "peloton"
+      case .wahoo: return "wahoo"
+      case .zwift: return "zwift"
+      case .eightSleep: return "eight_sleep"
+      case .withings: return "withings"
+      case .googleFit: return "google_fit"
+      case .hammerhead: return "hammerhead"
+      case .dexcom: return "dexcom"
+      case .myFitnessPal: return "my_fitness_pal"
+      case .healthConnect: return "health_connect"
+      case let .unknown(rawValue): return rawValue
+      }
     }
 
-    public init(rawValue: String) {
-      self.rawValue = rawValue
+    public init?(rawValue: String) {
+      switch rawValue {
+      case "beurer_ble": self = .beurerBLE
+      case "beurer_api": self = .beurer
+      case "omron_ble": self = .omronBLE
+      case "accuchek_ble": self = .accuchekBLE
+      case "contour_ble": self = .contourBLE
+      case "apple_health_kit": self = .appleHealthKit
+      case "manual": self = .manual
+      case "ihealth": self = .iHealth
+      case "freestyle_libre_ble": self = .libreBLE
+      case "freestyle_libre": self = .libre
+      case "oura": self = .oura
+      case "garmin": self = .garmin
+      case "fitbit": self = .fitbit
+      case "whoop": self = .whoop
+      case "strava": self = .strava
+      case "renpho": self = .renpho
+      case "peloton": self = .peloton
+      case "wahoo": self = .wahoo
+      case "zwift": self = .zwift
+      case "eight_sleep": self = .eightSleep
+      case "withings": self = .withings
+      case "google_fit": self = .googleFit
+      case "hammerhead": self = .hammerhead
+      case "dexcom": self = .dexcom
+      case "my_fitness_pal": self = .myFitnessPal
+      case "health_connect": self = .healthConnect
+      default: self = .unknown(rawValue)
+      }
     }
   }
 }

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/TaggedPayload.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/TaggedPayload.swift
@@ -5,13 +5,13 @@ public struct TaggedPayload: Encodable {
   public let startDate: Date?
   public let endDate: Date?
   public let timeZone: String
-  public let provider: Provider
+  public let provider: Provider.Slug
   public let data: VitalAnyEncodable
   
   public init(
     stage: Stage = .daily,
     timeZone: TimeZone,
-    provider: Provider = .manual,
+    provider: Provider.Slug = .manual,
     data: VitalAnyEncodable
   ) {
     self.provider = provider

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Endpoints+Extensions.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Endpoints+Extensions.swift
@@ -3,7 +3,7 @@ import Foundation
 func makeBaseQuery(
   startDate: Date,
   endDate: Date?,
-  provider: Provider? = nil
+  provider: Provider.Slug? = nil
 ) -> [(String, String?)] {
   
   let formatter = DateFormatter()

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Link.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Link.swift
@@ -38,7 +38,7 @@ public extension VitalClient.Link {
   }
   
   func createLinkToken(
-    provider: Provider?,
+    provider: Provider.Slug?,
     redirectURL: String?
   ) async throws -> String {
     
@@ -55,7 +55,7 @@ public extension VitalClient.Link {
   
   func createConnectedSource(
     _ userId: UUID,
-    provider: Provider
+    provider: Provider.Slug
   ) async throws -> Void {
     
     let configuration = await self.client.configuration.get()
@@ -82,14 +82,14 @@ public extension VitalClient.Link {
   }
   
   func createConnectedSource(
-    for provider: Provider
+    for provider: Provider.Slug
   ) async throws -> Void {
     let userId = await self.client.userId.get()
     try await createConnectedSource(userId, provider: provider)
   }
   
   func createProviderLink(
-    provider: Provider? = nil,
+    provider: Provider.Slug? = nil,
     redirectURL: String
   ) async throws -> URL {
     let configuration = await self.client.configuration.get()
@@ -105,7 +105,7 @@ public extension VitalClient.Link {
   }
 
   func createOAuthProvider(
-    provider: Provider,
+    provider: Provider.Slug,
     redirectURL: String? = nil
   ) async throws -> CreateOAuthProviderResponse {
     let configuration = await self.client.configuration.get()
@@ -122,7 +122,7 @@ public extension VitalClient.Link {
   
   func createEmailProvider(
     email: String,
-    provider: Provider,
+    provider: Provider.Slug,
     region: Environment.Region,
     redirectURL: String? = nil
   ) async throws -> CreateEmailProviderResponse {

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Summary.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Summary.swift
@@ -19,7 +19,7 @@ public extension VitalClient.Summary {
   func post(
     _ summaryData: SummaryData,
     stage: TaggedPayload.Stage,
-    provider: Provider,
+    provider: Provider.Slug,
     timeZone: TimeZone
   ) async throws -> Void {
     let userId = await self.client.userId.get()
@@ -43,7 +43,7 @@ public extension VitalClient.Summary {
   func sleepsSummary(
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [SleepSummary] {
     let userId = await self.client.userId.get()
     let configuration = await self.client.configuration.get()
@@ -61,7 +61,7 @@ public extension VitalClient.Summary {
   func sleepsRaw(
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [AnyDecodable] {
     let userId = await self.client.userId.get()
     let configuration = await self.client.configuration.get()
@@ -79,7 +79,7 @@ public extension VitalClient.Summary {
   func sleepsSummaryWithStream(
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [SleepSummary] {
     let userId = await self.client.userId.get()
     let configuration = await self.client.configuration.get()
@@ -97,7 +97,7 @@ public extension VitalClient.Summary {
   func activitySummary(
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [ActivitySummary] {
     let userId = await self.client.userId.get()
     let configuration = await self.client.configuration.get()
@@ -115,7 +115,7 @@ public extension VitalClient.Summary {
   func activityRaw(
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [AnyDecodable] {
     let userId = await self.client.userId.get()
     let configuration = await self.client.configuration.get()
@@ -133,7 +133,7 @@ public extension VitalClient.Summary {
   func workoutSummary(
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [WorkoutSummary] {
     let userId = await self.client.userId.get()
     let configuration = await self.client.configuration.get()
@@ -151,7 +151,7 @@ public extension VitalClient.Summary {
   func workoutRaw(
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [AnyDecodable] {
     let userId = await self.client.userId.get()
     let configuration = await self.client.configuration.get()
@@ -169,7 +169,7 @@ public extension VitalClient.Summary {
   func body(
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [BodySummary] {
     let userId = await self.client.userId.get()
     let configuration = await self.client.configuration.get()
@@ -187,7 +187,7 @@ public extension VitalClient.Summary {
   func bodyRaw(
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [AnyDecodable] {
     let userId = await self.client.userId.get()
     let configuration = await self.client.configuration.get()

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
@@ -33,7 +33,7 @@ public extension VitalClient.TimeSeries {
   func post(
     _ timeSeriesData: TimeSeriesData,
     stage: TaggedPayload.Stage,
-    provider: Provider,
+    provider: Provider.Slug,
     timeZone: TimeZone
   ) async throws -> Void {
     let userId = await self.client.userId.get()
@@ -57,7 +57,7 @@ public extension VitalClient.TimeSeries {
     resource: SimpleTimeSeriesResource,
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [TimeSeriesDataPoint] {
     
     let userId = await self.client.userId.get()
@@ -77,7 +77,7 @@ public extension VitalClient.TimeSeries {
   func getBloodPressure(
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [BloodPressureDataPoint] {
     
     let userId = await self.client.userId.get()

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+User.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+User.swift
@@ -14,13 +14,8 @@ public extension VitalClient {
 }
 
 public extension VitalClient.User {
-  
-  func userConnectedSources() async throws -> [Provider] {
-    let providers: [FullProvider] = try await self.userConnectedSources()
-    return providers.compactMap { Provider(rawValue: $0.slug) }
-  }
 
-  func userConnectedSources() async throws -> [FullProvider] {
+  func userConnectedSources() async throws -> [Provider] {
     let userId = await self.client.userId.get()
     let configuration = await self.client.configuration.get()
 
@@ -29,7 +24,7 @@ public extension VitalClient.User {
     let request: Request<ProviderResponse> = .init(path: path, method: .get)
     let response = try await configuration.apiClient.send(request)
     let providers = response.value.providers.map {
-      FullProvider.init(name: $0.name, slug: $0.slug, logo: $0.logo)
+      Provider(name: $0.name, slug: $0.slug, logo: $0.logo)
     }
 
     return providers
@@ -65,7 +60,7 @@ public extension VitalClient.User {
     )
   }
   
-  func deregisterProvider(provider: Provider) async throws -> Void {
+  func deregisterProvider(provider: Provider.Slug) async throws -> Void {
     let userId = await self.client.userId.get()
     let configuration = await self.client.configuration.get()
     

--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -325,7 +325,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
     await shared._setUserId(newUserId)
   }
   
-  public func isUserConnected(to provider: Provider) async throws -> Bool {
+  public func isUserConnected(to provider: Provider.Slug) async throws -> Bool {
     let userId = await userId.get()
     let storage = await configuration.get().storage
     
@@ -334,10 +334,10 @@ let user_secureStorageKey: String = "user_secureStorageKey"
     }
     
     let connectedSources: [Provider] = try await self.user.userConnectedSources()
-    return connectedSources.contains(provider)
+    return connectedSources.contains { $0.slug == provider }
   }
   
-  public func checkConnectedSource(for provider: Provider) async throws {
+  public func checkConnectedSource(for provider: Provider.Slug) async throws {
     let userId = await userId.get()
     let storage = await configuration.get().storage
     

--- a/Sources/VitalCore/Core/Storage/VitalCoreStorage.swift
+++ b/Sources/VitalCore/Core/Storage/VitalCoreStorage.swift
@@ -2,8 +2,8 @@ import SwiftUI
 import HealthKit
 
 public struct VitalBackStorage {
-  public var isConnectedSourceStored: (UUID, Provider) -> Bool
-  public var storeConnectedSource: (UUID, Provider) -> Void
+  public var isConnectedSourceStored: (UUID, Provider.Slug) -> Bool
+  public var storeConnectedSource: (UUID, Provider.Slug) -> Void
   
   public var flagResource: (VitalResource) -> Void
   public var isResourceFlagged: (VitalResource) -> Bool
@@ -25,7 +25,7 @@ public struct VitalBackStorage {
     let defaultValue: [String: String] = [:]
     userDefaults.register(defaults: defaultValue)
     
-    let generateKey: (UUID, Provider) -> String = { userId, provider in
+    let generateKey: (UUID, Provider.Slug) -> String = { userId, provider in
       return "\(userId.uuidString)-\(provider.rawValue)"
     }
     
@@ -65,7 +65,7 @@ public struct VitalBackStorage {
 
     var dateStorage: [String: Double] = [:]
 
-    let generateKey: (UUID, Provider) -> String = { userId, provider in
+    let generateKey: (UUID, Provider.Slug) -> String = { userId, provider in
       return "\(userId.uuidString)-\(provider.rawValue)"
     }
     
@@ -104,11 +104,11 @@ class VitalCoreStorage {
     self.storage = storage
   }
   
-  func storeConnectedSource(for userId: UUID, with provider: Provider) {
+  func storeConnectedSource(for userId: UUID, with provider: Provider.Slug) {
     storage.storeConnectedSource(userId, provider)
   }
   
-  func isConnectedSourceStored(for userId: UUID, with provider: Provider) -> Bool {
+  func isConnectedSourceStored(for userId: UUID, with provider: Provider.Slug) -> Bool {
     return storage.isConnectedSourceStored(userId, provider)
   }
   

--- a/Sources/VitalDevices/DeviceManager+Brands.swift
+++ b/Sources/VitalDevices/DeviceManager+Brands.swift
@@ -114,7 +114,7 @@ public extension DevicesManager {
     ]
   }
   
-  static func provider(for brand: Brand) -> Provider {
+  static func provider(for brand: Brand) -> Provider.Slug {
     switch brand {
       case .omron:
         return .omronBLE

--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -177,8 +177,8 @@ extension VitalHealthKitStore {
 }
 
 struct VitalClientProtocol {
-  var post: (ProcessedResourceData, TaggedPayload.Stage, Provider, TimeZone) async throws -> Void
-  var checkConnectedSource: (Provider) async throws -> Void
+  var post: (ProcessedResourceData, TaggedPayload.Stage, Provider.Slug, TimeZone) async throws -> Void
+  var checkConnectedSource: (Provider.Slug) async throws -> Void
 }
 
 extension VitalClientProtocol {

--- a/Tests/VitalCoreTests/ProviderTests.swift
+++ b/Tests/VitalCoreTests/ProviderTests.swift
@@ -11,9 +11,26 @@ class ProviderTests: XCTestCase {
 
     XCTAssertEqual(data, "\"\(slug.rawValue)\"".data(using: .utf8))
   }
+
   func test_provider_slug_decoding() throws {
     let decoder = JSONDecoder()
     let slug = Provider.Slug.appleHealthKit
+    let data = try XCTUnwrap("\"\(slug.rawValue)\"".data(using: .utf8))
+
+    XCTAssertEqual(slug, try decoder.decode(Provider.Slug.self, from: data))
+  }
+
+  func test_provider_slug_encoding_unknown_value() throws {
+    let encoder = JSONEncoder()
+    let slug = Provider.Slug.unknown("whomst")
+    let data = try encoder.encode(slug)
+
+    XCTAssertEqual(data, "\"\(slug.rawValue)\"".data(using: .utf8))
+  }
+
+  func test_provider_slug_decoding_unknown_value() throws {
+    let decoder = JSONDecoder()
+    let slug = Provider.Slug.unknown("whomst")
     let data = try XCTUnwrap("\"\(slug.rawValue)\"".data(using: .utf8))
 
     XCTAssertEqual(slug, try decoder.decode(Provider.Slug.self, from: data))

--- a/Tests/VitalCoreTests/ProviderTests.swift
+++ b/Tests/VitalCoreTests/ProviderTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+import Mocker
+
+@testable import VitalCore
+
+class ProviderTests: XCTestCase {
+  func test_provider_slug_encoding() throws {
+    let encoder = JSONEncoder()
+    let slug = Provider.Slug.appleHealthKit
+    let data = try encoder.encode(slug)
+
+    XCTAssertEqual(data, "\"\(slug.rawValue)\"".data(using: .utf8))
+  }
+  func test_provider_slug_decoding() throws {
+    let decoder = JSONDecoder()
+    let slug = Provider.Slug.appleHealthKit
+    let data = try XCTUnwrap("\"\(slug.rawValue)\"".data(using: .utf8))
+
+    XCTAssertEqual(slug, try decoder.decode(Provider.Slug.self, from: data))
+  }
+}

--- a/Tests/VitalCoreTests/VitalClientTests.swift
+++ b/Tests/VitalCoreTests/VitalClientTests.swift
@@ -7,7 +7,7 @@ let environment = Environment.sandbox(.us)
 let userId = UUID()
 let apiKey = UUID().uuidString
 let apiVersion = "2.0"
-let provider = Provider.strava
+let provider = Provider.Slug.strava
 
 class VitalClientTests: XCTestCase {
   


### PR DESCRIPTION
Merge the provider enum and the FullProvider struct into one model type, so that we don't expose two methods that are ultimately mapped to the same endpoint.

Also for API forward compatibility, adopted RawRepresentable struct over enum for the typed source slug. This enables new provider slugs returned by the API but unrecognised by the SDK to still be parsed, inspected & used, whereas the decoding would fail upon unrecognised value if it remained as an enum.