### PR TITLE
VIT-2679: Persistent Logging with shareable log archives

### DIFF
--- a/Examples/iOS/Root.swift
+++ b/Examples/iOS/Root.swift
@@ -21,14 +21,13 @@ struct ExampleApp: App {
     WindowGroup {
       WithViewStore(appStore) { viewStore in
         TabView {
-          #if DEBUG
           HealthKitExample()
             .tabItem {
               Image(systemName: "suit.heart")
               Text("HealthKit")
             }
             .tag(0)
-          #endif
+
           DevicesExample.RootView(store: devicesStore)
             .tabItem {
               Image(systemName: "laptopcomputer.and.iphone")

--- a/Examples/iOS/Settings/Settings.swift
+++ b/Examples/iOS/Settings/Settings.swift
@@ -198,6 +198,7 @@ let settingsReducer = Reducer<Settings.State, Settings.Action, Settings.Environm
             )
           }
           
+
           await VitalHealthKitClient.configure(
             .init(
               backgroundDeliveryEnabled: true,
@@ -206,7 +207,7 @@ let settingsReducer = Reducer<Settings.State, Settings.Action, Settings.Environm
             )
           )
         }
-        
+
         return .didConfigureSDK
       } catch: { error in
         let alert = AlertState<Settings.Action> {
@@ -220,7 +221,7 @@ let settingsReducer = Reducer<Settings.State, Settings.Action, Settings.Environm
         }
         return .binding(BindingAction.set(\.$alert, alert))
       }
-            
+
       return effect
         .receive(on: DispatchQueue.main)
         .eraseToEffect()
@@ -364,6 +365,20 @@ extension Settings {
                   }
                 })
                 .disabled(viewStore.sdkIsConfigured == false)
+              }
+            }
+
+            Section("Logging") {
+              Toggle(
+                "Persistent Logging",
+                isOn: Binding(
+                  get: { VitalPersistentLogger.isEnabled },
+                  set: { VitalPersistentLogger.isEnabled = $0 }
+                )
+              )
+
+              Button("Share Persistent Logs") {
+                VitalHealthKitClient.createAndShareLogArchive()
               }
             }
           }

--- a/Sources/VitalCore/Core/Log/PersistentLog.swift
+++ b/Sources/VitalCore/Core/Log/PersistentLog.swift
@@ -1,0 +1,214 @@
+import Foundation
+import OSLog
+import Dispatch
+import Darwin
+
+
+public final class VitalPersistentLogger: @unchecked Sendable {
+  private let queue = DispatchQueue(label: "io.tryvital.PersistentLogger", target: .global(qos: .utility))
+  private var lastDump: Date = .distantPast
+
+  @_spi(VitalSDKInternals)
+  public static var shared: VitalPersistentLogger? {
+    _lock.withLock {
+      if let logger = Self._shared {
+        return logger
+      } else {
+        return Self.checkEnabled(context: "defaults on first access")
+      }
+    }
+  }
+
+  private static let _lock = NSLock()
+  private static var _shared: VitalPersistentLogger? = nil
+  private static let userDefaultsKey = "io.tryvital.VitalPersistentLogger.enabled"
+
+  /// Enable persistent logging in Vital SDK. The enablement is persistent across app launches.
+  ///
+  /// When enabled, Vital dumps state snapshots, log messages and network request bodies from itself to the system-desginated
+  /// temporary directory in persistent storage. Note that they may be eligible to be purged by the OS when the
+  /// persistent storage is under pressure.
+  ///
+  /// You can retrieve the logs by either:
+  /// * `VitalHealthKitClient.Type.createLogArchive()` in the form of a file URL; or
+  /// * `VitalHealthKitClient.Type.createAndShareLogArchive()` where the system share sheet is prompted with the log archive.
+  ///
+  /// - warning: Avoid enabling this by default, especially in production.
+  public static var isEnabled: Bool {
+    get { UserDefaults.standard.bool(forKey: Self.userDefaultsKey) }
+    set {
+      _lock.withLock {
+        UserDefaults.standard.set(newValue, forKey: Self.userDefaultsKey)
+        checkEnabled(context: "explicit enablement")
+      }
+    }
+  }
+
+  @discardableResult
+  private static func checkEnabled(context: StaticString) -> VitalPersistentLogger? {
+    switch (isEnabled, _shared) {
+    case (false, nil):
+      return nil
+
+    case (false, .some):
+      _shared = nil
+
+      VitalLogger.core.info("[PersistentLogger] disabled")
+      return nil
+
+    case (true, nil):
+      let persistentLogger = VitalPersistentLogger()
+      _shared = persistentLogger
+
+      VitalLogger.core.info("[PersistentLogger] enabled via \(context, privacy: .public)")
+      return persistentLogger
+
+    case let (true, logger?):
+      return logger
+    }
+  }
+
+  public init() {}
+
+  @_spi(VitalSDKInternals)
+  public func directoryURL(for category: VitalLogger.Category?) -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory())
+    var directoryUrl = url.appendingPathComponent("vital", isDirectory: true)
+
+    if let category = category {
+      directoryUrl = directoryUrl.appendingPathComponent(category.rawValue, isDirectory: true)
+    }
+
+    return directoryUrl
+  }
+
+  @_spi(VitalSDKInternals)
+  public func dayURL(for category: VitalLogger.Category) -> URL {
+    let directoryUrl = directoryURL(for: category)
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate, .withDashSeparatorInDate]
+    let calendarDate = formatter.string(from: Date())
+
+    let fileUrl = directoryUrl.appendingPathComponent("\(calendarDate).log")
+
+    let exists = FileManager.default.fileExists(atPath: fileUrl.absoluteString)
+
+    if !exists {
+      try! FileManager.default.createDirectory(at: directoryUrl, withIntermediateDirectories: true)
+      FileManager.default.createFile(atPath: fileUrl.absoluteString, contents: Data())
+    }
+
+    return fileUrl
+  }
+
+  @_spi(VitalSDKInternals)
+  public func dumpOSLog(_ category: VitalLogger.Category, since date: Date? = nil) {
+    if #available(iOS 15.0, *) {
+      queue.async {
+        do {
+          let store = try OSLogStore(scope: .currentProcessIdentifier)
+
+          var lastDump = min(self.lastDump, date ?? .distantPast)
+          let position = store.position(date: lastDump)
+
+          let predicate = NSPredicate(format: "subsystem = %@ AND category = %@", VitalLogger.subsystem, category.rawValue)
+          let entries = try store.getEntries(at: position, matching: predicate)
+
+          let formatter = ISO8601DateFormatter()
+          formatter.formatOptions = [.withInternetDateTime]
+
+          self._log(category) { writeString, _ in
+            for entry in entries {
+              let level = (entry as? OSLogEntryLog)?.level ?? .undefined
+              writeString("\(level.name) \(formatter.string(from: entry.date)) \(entry.composedMessage)")
+
+              lastDump = entry.date
+            }
+          }
+
+          self.lastDump = lastDump
+        } catch let error {
+          self._log(category) { writeString, _ in
+            writeString("<OSLogDump failure: \(error)>")
+          }
+        }
+      }
+    }
+  }
+
+  func log<T>(_ request: Request<T>) {
+    queue.async {
+      self._log(.requests) { writeString, writeData in
+        writeString("\(request.method.rawValue) \(request.url?.absoluteString ?? "UNKNOWN_URL")")
+
+        if let body = request.body {
+          let encoder = JSONEncoder()
+          encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+          do {
+            let data = try encoder.encode(body)
+            writeString("uncompressed size: \(data.count) bytes")
+            writeData(data)
+          } catch let error {
+            writeString("<encoder failure: \(error)>")
+          }
+        }
+
+        // New line
+        writeString("")
+      }
+    }
+  }
+
+  private func _log(_ category: VitalLogger.Category, _ message: @escaping ((String) -> Void, (Data) -> Void) throws -> Void) {
+    do {
+      let stream = OutputStream(url: dayURL(for: category), append: true)!
+      stream.open()
+      defer { stream.close() }
+
+      func writeString(_ string: String) {
+        var string = string + "\r\n"
+        string.withUTF8 { buffer in
+          let bytesWritten = stream.write(buffer.baseAddress!, maxLength: buffer.count)
+          precondition(bytesWritten > 0)
+        }
+      }
+
+      func writeData(_ bytes: Data) {
+        bytes.withUnsafeBytes { buffer in
+          let bytesWritten = stream.write(buffer.baseAddress!, maxLength: buffer.count)
+          precondition(bytesWritten > 0)
+        }
+
+        // New line
+        writeString("")
+      }
+
+      try message(writeString, writeData)
+    } catch _ {
+
+    }
+  }
+}
+
+@available(iOS 15.0, *)
+extension OSLogEntryLog.Level {
+  fileprivate var name: String {
+    switch self {
+    case .undefined:
+      return "UNDEFINED"
+    case .debug:
+      return "DEBUG"
+    case .info:
+      return "INFO"
+    case .notice:
+      return "NOTICE"
+    case .error:
+      return "ERROR"
+    case .fault:
+      return "FAULT"
+    @unknown default:
+      return "UNKNOWN"
+    }
+  }
+}

--- a/Sources/VitalCore/Core/Logs/VitalLogger.swift
+++ b/Sources/VitalCore/Core/Logs/VitalLogger.swift
@@ -3,6 +3,13 @@ import OSLog
 public enum VitalLogger {
   public static let subsystem = "io.tryvital.vital-ios"
 
-  public static let core = Logger(subsystem: Self.subsystem, category: "core")
-  public static let healthKit = Logger(subsystem: Self.subsystem, category: "healthKit")
+  public static let core = Logger(subsystem: Self.subsystem, category: Category.core.rawValue)
+  public static let requests = Logger(subsystem: Self.subsystem, category: Category.requests.rawValue)
+  public static let healthKit = Logger(subsystem: Self.subsystem, category: Category.healthKit.rawValue)
+
+  public enum Category: String {
+    case core
+    case requests
+    case healthKit
+  }
 }

--- a/Sources/VitalCore/Core/Storage/VitalCoreStorage.swift
+++ b/Sources/VitalCore/Core/Storage/VitalCoreStorage.swift
@@ -17,6 +17,8 @@ public struct VitalBackStorage {
   public var remove: (String) -> Void
   
   public var clean: () -> Void
+
+  public var dump: () -> [String: Any?]
   
   public static var live: VitalBackStorage {
     
@@ -55,6 +57,8 @@ public struct VitalBackStorage {
       userDefaults.removeObject(forKey: key)
     } clean: {
       userDefaults.removePersistentDomain(forName: "tryVital")
+    } dump: {
+      userDefaults.persistentDomain(forName: "tryVital") ?? [:]
     }
   }
   
@@ -93,11 +97,13 @@ public struct VitalBackStorage {
     } clean: {
       storage = [:]
       dataStorage = [:]
+    } dump: {
+      return [:]
     }
   }
 }
 
-class VitalCoreStorage {
+public class VitalCoreStorage {
   private let storage: VitalBackStorage
   
   init(storage: VitalBackStorage) {

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -1439,8 +1439,11 @@ private func _average(_ values: [QuantitySample], calendar: Calendar) -> [Quanti
     var totalGrouped: Double = 0
     var count = 0
   }
-  
-  var outcome: [QuantitySample] = ordered.reduce(into: Payload()) { payload, newValue in
+
+  let payload = Payload()
+  payload.samples.reserveCapacity(ordered.count)
+
+  var outcome: [QuantitySample] = ordered.reduce(into: payload) { payload, newValue in
     payload.count = payload.count + 1
     
     if let lastValue = payload.samples.last {

--- a/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
+++ b/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
@@ -92,6 +92,14 @@ class VitalHealthKitStorage {
   func remove(key: String) {
     storage.remove(key)
   }
+
+  func clean() {
+    storage.clean()
+  }
+
+  func dump() -> [String: Any?] {
+    storage.dump()
+  }
 }
 
 struct StoredAnchor {

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient+Logs.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient+Logs.swift
@@ -1,0 +1,208 @@
+import Foundation
+import UIKit
+import HealthKit
+@_spi(VitalSDKInternals) import VitalCore
+import AppleArchive
+import System
+
+extension VitalHealthKitClient {
+  public struct LogArchivalError: Error, CustomStringConvertible {
+    public let description: String
+
+    public init(_ description: String) {
+      self.description = description
+    }
+  }
+
+  @available(iOS 15.0, *)
+  public static func createAndShareLogArchive() {
+    let archiveUrlTask = Task { try await Self.createLogArchive() }
+
+    Task { @MainActor in
+      let result = await archiveUrlTask.result
+
+      var topViewController = UIApplication.shared.connectedScenes
+        .compactMap { $0 as? UIWindowScene }
+        .first { $0.session.role == .windowApplication }?
+        .keyWindow?
+        .rootViewController
+
+      while let modal = topViewController?.presentedViewController {
+        topViewController = modal
+      }
+
+      switch result {
+      case let .success(archiveUrl):
+        topViewController?.present(
+          UIActivityViewController(activityItems: [archiveUrl], applicationActivities: nil),
+          animated: true
+        )
+
+      case let .failure(error):
+        let alertController = UIAlertController(
+          title: "Failed to create archive",
+          message: String(describing: error),
+          preferredStyle: .alert
+        )
+        alertController.addAction(UIAlertAction(title: "OK", style: .default))
+        topViewController?.present(alertController, animated: true)
+      }
+    }
+  }
+
+  @available(iOS 15.0, *)
+  public static func createLogArchive() async throws -> URL {
+    guard let logger = VitalPersistentLogger.shared else {
+      throw LogArchivalError("VitalPersistentLogger is not enabled.")
+    }
+
+    try await logStateSnapshot()
+
+    let rootDirectoryURL = logger.directoryURL(for: nil)
+    let archiveUrl = FileManager.default.temporaryDirectory
+      .appendingPathComponent("vital-\(Int(Date.now.timeIntervalSince1970)).aar")
+    guard let archiveFilePath = FilePath(archiveUrl), let rootDirectoryPath = FilePath(rootDirectoryURL) else {
+      throw LogArchivalError("Failed to create FilePath for archive.")
+    }
+
+    do {
+      try ArchiveByteStream.withFileStream(
+        path: archiveFilePath,
+        mode: .writeOnly,
+        options: [.create],
+        permissions: FilePermissions(rawValue: 0o644)
+      ) { fileStream in
+        try ArchiveByteStream.withCompressionStream(
+          using: .lzfse,
+          writingTo: fileStream
+        ) { compressionStream in
+          try ArchiveStream.withEncodeStream(writingTo: compressionStream) { encodeStream in
+            try encodeStream.writeDirectoryContents(
+              archiveFrom: rootDirectoryPath,
+              keySet: .defaultForArchive
+            )
+          }
+        }
+      }
+    } catch let error {
+      throw LogArchivalError("Failed to create archive at \(archiveUrl.path): \(error)")
+    }
+
+    return archiveUrl
+  }
+
+  @available(iOS 15.0, *)
+  @discardableResult
+  public static func logStateSnapshot() async throws -> URL {
+    guard let logger = VitalPersistentLogger.shared else {
+      throw LogArchivalError("VitalPersistentLogger is not enabled.")
+    }
+
+    let userId = VitalClient.currentUserId
+    let vitalCoreConfiguration = VitalClient.shared.configuration.value
+    let vitalHealthKitConfiguration = shared.configuration.value
+
+    let rootDirectoryURL = logger.directoryURL(for: nil)
+    let logURL = rootDirectoryURL.appendingPathComponent("vitalhealthkit-state-\(Int(Date.now.timeIntervalSince1970)).log")
+
+    try FileManager.default.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+    let stream = OutputStream(url: logURL, append: false)!
+    stream.open()
+    defer { stream.close() }
+
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+
+    func write(_ string: String) {
+      var string = string + "\r\n"
+      string.withUTF8 { buffer in
+        let bytesWritten = stream.write(buffer.baseAddress!, maxLength: buffer.count)
+        precondition(bytesWritten > 0)
+      }
+    }
+
+    let environmentMessage = await Task { @MainActor in
+      """
+      OS_VERSION: \(UIDevice.current.systemVersion)
+      DEVICE_MODEL: \(UIDevice.current.model)
+      """
+    }.value
+
+    write("""
+    \(environmentMessage)
+    VITAL_ENV: \((vitalCoreConfiguration?.environment).map(String.init(describing:)) ?? "nil")
+    VITAL_API_VERSION: \(vitalCoreConfiguration?.apiVersion ?? "nil")
+    VITAL_AUTH_MODE: \(vitalCoreConfiguration?.authMode.rawValue ?? "nil")
+    USER_ID: \(userId ?? "nil")
+    VITAL_HK_CONFIG: \(vitalHealthKitConfiguration.map(String.init(describing:)) ?? "nil")
+    """)
+
+    write(">>> HKHEALTHSTORE")
+    let healthStore = HKHealthStore()
+
+    for objectType in VitalResource.all.flatMap(toHealthKitTypes) {
+      let requestStatus = try await healthStore.statusForAuthorizationRequest(toShare: [], read: [objectType])
+      let authorizationStatus = healthStore.authorizationStatus(for: objectType)
+      let remarks = (requestStatus == .unnecessary && authorizationStatus == .sharingDenied) ? "(readonly granted?)" : ""
+      write("\(objectType.identifier) = \(requestStatus.name),\(authorizationStatus.name) \(remarks)")
+    }
+
+    write(">>> VITALHEALTHKIT_STORAGE")
+
+    let storageDump = shared.storage.dump().mapValues { value -> Any? in
+      switch value {
+      case let value as NSDate:
+        return formatter.string(from: value as Date)
+      case let data as NSData:
+        let data = data as Data
+
+        // First try HKQueryAnchor
+        if let anchor = try? NSKeyedUnarchiver.unarchivedObject(ofClass: HKQueryAnchor.self, from: data) {
+          return "\(anchor)"
+        }
+
+        // Then try JSON
+        return String(data: data, encoding: .utf8) ?? "<NSData with unknown encoding>"
+      default:
+        return value
+      }
+    }
+    let storageJson = try JSONSerialization.data(withJSONObject: storageDump, options: [.prettyPrinted, .sortedKeys])
+    write(String(data: storageJson, encoding: .utf8) ?? "")
+
+    return logURL
+  }
+}
+
+
+extension HKAuthorizationStatus {
+  fileprivate var name: String {
+    switch self {
+    case .notDetermined:
+      return "not_determined"
+    case .sharingAuthorized:
+      return "sharing_authorized"
+    case .sharingDenied:
+      return "sharing_denied"
+    @unknown default:
+      return "UNKNOWN"
+    }
+  }
+}
+
+
+extension HKAuthorizationRequestStatus {
+  fileprivate var name: String {
+    switch self {
+    case .shouldRequest:
+      return "should_request"
+    case .unknown:
+      return "unknown"
+    case .unnecessary:
+      return "unnecessary"
+    @unknown default:
+      return "UNKNOWN"
+    }
+  }
+}

--- a/Tests/VitalCoreTests/VitalClientTests.swift
+++ b/Tests/VitalCoreTests/VitalClientTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Mocker
 
-@testable import VitalCore
+@testable @_spi(VitalSDKInternals) import VitalCore
 
 let environment = Environment.sandbox(.us)
 let userId = UUID().uuidString


### PR DESCRIPTION
Opt-in API to:

1. Record network request and OSLogStore incremental dumps to secondary storage. This is disabled by default, and can be opt-in by setting `VitalPersistentLogger.isEnabled`:

    ```swift
    // Settings screen
    Toggle(
      "Persistent Logging",
      isOn: Binding(
        get: { VitalPersistentLogger.isEnabled },
        set: { VitalPersistentLogger.isEnabled = $0 }
      )
    )
    ```

    `VitalPersistentLogger.isEnabled` is persistent across app launches once enabled.

    OSLogStore dump is triggered every time `VitalHealthKitClient.sync(...)` returns (completed or failed).

2. create a shareable .aar (Apple Archive)

    ```swift
    // Before calling any Vital SDK API
    VitalHealthKit.createAndShareLogArchive()
    ```

4. Added a toggle for enabling persistent logging, and a button to share log archive in the Example app > Settings tab.


For log archive creation purposes, some internal declarations in VitalCore have to be exposed to VitalHealthKit. Instead of giving them public access level, `@_spi(VitalSDKInternals) public` is used instead. `@_spi` ensures that SDK consumers importing VitalCore normally (i.e., simply `import VitalCore`) would not see any of these internal declarations/symbols.

While on paper we can use the `package` access level added by [SE-0386](https://github.com/apple/swift-evolution/blob/main/proposals/0386-package-access-modifier.md#_spi), this feature is SPM-exclusive, and we are required to support CocoaPods for (at least) Flutter/RN in the foreseeable future.

* [@_spi as explained by the compiler notes](https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_spispiname)
* [@_spi explained by a blogpost](https://blog.eidinger.info/system-programming-interfaces-spi-in-swift-explained)
* [@_spi as explained by SE-0386](https://github.com/apple/swift-evolution/blob/main/proposals/0386-package-access-modifier.md#_spi)
