### PR TITLE
Use endDate DESC to lookup last sample

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -407,7 +407,7 @@ struct StatisticsQueryDependencies {
             sampleType: type,
             predicate: makePredicate(),
             limit: 1,
-            sortDescriptors: [NSSortDescriptor(key: HKPredicateKeyPathStartDate, ascending: false)]
+            sortDescriptors: [NSSortDescriptor(key: HKPredicateKeyPathEndDate, ascending: false)]
           ) { _, samples, error in
             continuation.resume(returning: samples?.first?.endDate)
           }


### PR DESCRIPTION
lastSampleDate currently uses (equivalent of) `SELECT endDate ORDER BY startDate DESC LIMIT 1`. This can go wrong because each sample can have different durations, and therefore the endDate needs not reproduce the exact same chronological order as the startDate.

This causes the invariant check on `first <= last` being triggered in the wild (per Sentry)


Switch to `ORDER BY endDate DESC` instead.