### PR TITLE
[VIT-2680] Mark log interpolations with privacy: public

### DIFF
--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
@@ -49,7 +49,7 @@ public extension VitalClient.TimeSeries {
     let fullPath: String = await makePath(for: timeSeriesData.name, userId: userId.uuidString)
     let request: Request<Void> = .init(path: fullPath, method: .post, body: taggedPayload)
     
-    configuration.logger?.info("Posting TimeSeries data for: \(timeSeriesData.name)")
+    configuration.logger?.info("Posting TimeSeries data for: \(timeSeriesData.name, privacy: .public)")
     try await configuration.apiClient.send(request)
   }
   

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+User.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+User.swift
@@ -40,7 +40,7 @@ public extension VitalClient.User {
     let path = "/\(configuration.apiVersion)/\(path)/"
     let request: Request<CreateUserResponse> = .init(path: path, method: .post, body: payload)
     
-    configuration.logger?.info("Creating Vital's userId for id: \(payload.clientUserId)")
+    configuration.logger?.info("Creating Vital's userId for id: \(payload.clientUserId, privacy: .public)")
     let value = try await configuration.apiClient.send(request).value
     
     if setUserIdOnSuccess {

--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -200,7 +200,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       completion?()
       /// Bailout, there's nothing else to do here.
       /// (But still try to log it if we have a logger around)
-      shared.configuration.value?.logger?.error("Failed to perform automatic configuration: \(error)")
+      shared.configuration.value?.logger?.error("Failed to perform automatic configuration: \(error, privacy: .public)")
     }
   }
   
@@ -237,7 +237,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       logger = Logger(subsystem: "vital", category: "vital-network-client")
     }
     
-    logger?.info("VitalClient setup for environment \(String(describing: environment))")
+    logger?.info("VitalClient setup for environment \(String(describing: environment), privacy: .public)")
     
     let apiClientDelegate = VitalClientDelegate(
       environment: environment,
@@ -273,7 +273,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       try secureStorage.set(value: securePayload, key: core_secureStorageKey)
     }
     catch {
-      logger?.info("We weren't able to securely store VitalCoreSecurePayload: \(error.localizedDescription)")
+      logger?.info("We weren't able to securely store VitalCoreSecurePayload: \(error, privacy: .public)")
     }
     
     let coreConfiguration = VitalCoreConfiguration(
@@ -302,7 +302,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       }
     }
     catch {
-      configuration.logger?.info("We weren't able to get the stored userId VitalCoreSecurePayload: \(error.localizedDescription)")
+      configuration.logger?.info("We weren't able to get the stored userId VitalCoreSecurePayload: \(error, privacy: .public)")
     }
     
     self.userId.set(value: newUserId)
@@ -311,7 +311,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       try secureStorage.set(value: newUserId, key: user_secureStorageKey)
     }
     catch {
-      configuration.logger?.info("We weren't able to securely store VitalCoreSecurePayload: \(error.localizedDescription)")
+      configuration.logger?.info("We weren't able to securely store VitalCoreSecurePayload: \(error, privacy: .public)")
     }
   }
   

--- a/Sources/VitalCore/Core/Client/VitalClientDelegates.swift
+++ b/Sources/VitalCore/Core/Client/VitalClientDelegates.swift
@@ -34,7 +34,7 @@ class VitalClientDelegate: APIClientDelegate {
       return false
     }
     
-    self.logger?.info("Retrying after error: \(error.localizedDescription)")
+    self.logger?.info("Retrying after error: \(error, privacy: .public)")
     
     return true
   }
@@ -51,7 +51,7 @@ class VitalClientDelegate: APIClientDelegate {
       payload: data
     )
         
-    self.logger?.error("Failed request with error: \(networkError.localizedDescription)")
+    self.logger?.error("Failed request with error: \(networkError, privacy: .public)")
     throw networkError
   }
 }

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -1081,7 +1081,7 @@ func queryActivityDaySummaries(
     calendar.floatingDate(of: endTime)
   )
 
-  logger?.info("[Day Summary] lastComputed = \(startTime) now = \(endTime) datesToCompute = \(datesToCompute)")
+  logger?.info("[Day Summary] lastComputed = \(startTime, privacy: .public) now = \(endTime, privacy: .public) datesToCompute = \(datesToCompute, privacy: .public)")
 
   return try await withThrowingTaskGroup(
     of: ActivityPatch.DaySummary.self,

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -118,7 +118,7 @@ internal var logger: Logger? {
       completion?()
       /// Bailout, there's nothing else to do here.
       /// (But still try to log it if we have a logger around)
-      shared.logger?.error("Failed to perform automatic configuration: \(error)")
+      shared.logger?.error("Failed to perform automatic configuration: \(error, privacy: .public)")
     }
   }
 
@@ -137,7 +137,7 @@ internal var logger: Logger? {
       try secureStorage.set(value: configuration, key: health_secureStorageKey)
     }
     catch {
-      logger?.info("We weren't able to securely store Configuration: \(error.localizedDescription)")
+      logger?.info("We weren't able to securely store Configuration: \(error, privacy: .public)")
     }
     
     self.configuration.set(value: configuration)
@@ -245,11 +245,11 @@ extension VitalHealthKitClient {
       store.enableBackgroundDelivery(sampleType, .hourly) { [weak self] success, failure in
         
         guard failure == nil && success else {
-          self?.logger?.error("Failed to enable background delivery for type: \(String(describing: sampleType)). Did you enable \"Background Delivery\" in Capabilities?")
+          self?.logger?.error("Failed to enable background delivery for type: \(sampleType.identifier, privacy: .public). Did you enable \"Background Delivery\" in Capabilities?")
           return
         }
         
-        self?.logger?.info("Successfully enabled background delivery for type: \(String(describing: sampleType))")
+        self?.logger?.info("Successfully enabled background delivery for type: \(sampleType.identifier, privacy: .public)")
       }
     }
   }
@@ -275,7 +275,7 @@ extension VitalHealthKitClient {
           }
 
           guard error == nil else {
-            self.logger?.error("Failed to background deliver for \(String(describing: sampleTypes)) with \(error).")
+            self.logger?.error("Failed to background deliver for \(String(describing: sampleTypes), privacy: .public) with \(error, privacy: .public).")
 
             ///  We need a better way to handle if a failure happens here.
             return
@@ -310,7 +310,7 @@ extension VitalHealthKitClient {
         let query = HKObserverQuery(sampleType: sampleType, predicate: nil) {[weak self] query, handler, error in
           
           guard error == nil else {
-            self?.logger?.error("Failed to background deliver for \(String(describing: sampleType)).")
+            self?.logger?.error("Failed to background deliver for \(sampleType.identifier, privacy: .public).")
             
             ///  We need a better way to handle if a failure happens here.
             return
@@ -428,7 +428,7 @@ extension VitalHealthKitClient {
     let description = payload.description(store: store)
     let resource = payload.resource(store: store)
     
-    logger?.info("Syncing HealthKit \(infix): \(description)")
+    logger?.info("Syncing HealthKit \(infix, privacy: .public): \(description, privacy: .public)")
     
     do {
       // Signal syncing (so the consumer can convey it to the user)
@@ -460,7 +460,7 @@ extension VitalHealthKitClient {
           entitiesToStore.forEach(storage.store(entity:))
         }
 
-        logger?.info("Skipping. No new data available \(infix): \(description)")
+        logger?.info("Skipping. No new data available \(infix, privacy: .public): \(description, privacy: .public)")
         _status.send(.nothingToSync(resource))
 
         return
@@ -468,7 +468,7 @@ extension VitalHealthKitClient {
       
       if configuration.mode.isAutomatic {
         self.logger?.info(
-          "Automatic Mode. Posting data for stage \(stage) \(infix): \(description)"
+          "Automatic Mode. Posting data for stage \(stage, privacy: .public) \(infix, privacy: .public): \(description, privacy: .public)"
         )
         
         /// Make sure the user has a connected source set up
@@ -487,7 +487,7 @@ extension VitalHealthKitClient {
         )
       } else {
         self.logger?.info(
-          "Manual Mode. Skipping posting data for stage \(stage) \(infix): \(description)"
+          "Manual Mode. Skipping posting data for stage \(stage, privacy: .public) \(infix, privacy: .public): \(description, privacy: .public)"
         )
       }
       
@@ -497,7 +497,7 @@ extension VitalHealthKitClient {
       // Save the anchor/date on a succesfull network call
       entitiesToStore.forEach(storage.store(entity:))
       
-      logger?.info("Completed syncing \(infix): \(description)")
+      logger?.info("Completed syncing \(infix, privacy: .public): \(description, privacy: .public)")
       
       // Signal success
       _status.send(.successSyncing(resource, data))
@@ -509,7 +509,7 @@ extension VitalHealthKitClient {
     catch let error {
       // Signal failure
       logger?.error(
-        "Failed syncing data \(infix): \(description). Error: \(error.localizedDescription)"
+        "Failed syncing data \(infix, privacy: .public): \(description, privacy: .public). Error: \(error, privacy: .public)"
       )
       _status.send(.failedSyncing(resource, error))
     }


### PR DESCRIPTION
All OS log interpolations are by default `%{private}@`. This means the interpolation is redacted outside of development contexts (not redacted in local Xcode builds, etc, but redacted in e.g. syslog and OSLogStore when no debugger is attached).

Since we want to be able to read logs in production (#37), we need most, if not all, our log interpolations to be marked as `%{public}@`, so that they are able to survive the redaction in production to help troubleshooting.

