### PR TITLE
[VIT-2681] Use static OSLog loggers.

### DIFF
--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
@@ -49,7 +49,7 @@ public extension VitalClient.TimeSeries {
     let fullPath: String = await makePath(for: timeSeriesData.name, userId: userId)
     let request: Request<Void> = .init(path: fullPath, method: .post, body: taggedPayload)
     
-    configuration.logger?.info("Posting TimeSeries data for: \(timeSeriesData.name, privacy: .public)")
+    VitalLogger.core.info("Posting TimeSeries data for: \(timeSeriesData.name, privacy: .public)")
     try await configuration.apiClient.send(request)
   }
   

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+User.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+User.swift
@@ -40,7 +40,7 @@ public extension VitalClient.User {
     let path = "/\(configuration.apiVersion)/\(path)/"
     let request: Request<CreateUserResponse> = .init(path: path, method: .post, body: payload)
     
-    configuration.logger?.info("Creating Vital's userId for id: \(payload.clientUserId, privacy: .public)")
+    VitalLogger.core.info("Creating Vital's userId for id: \(payload.clientUserId, privacy: .public)")
     let value = try await configuration.apiClient.send(request).value
     
     if setUserIdOnSuccess {

--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -9,7 +9,6 @@ struct Credentials: Equatable, Hashable {
 }
 
 struct VitalCoreConfiguration {
-  var logger: Logger? = nil
   let apiVersion: String
   let apiClient: APIClient
   let environment: Environment
@@ -274,7 +273,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       completion?()
       /// Bailout, there's nothing else to do here.
       /// (But still try to log it if we have a logger around)
-      shared.configuration.value?.logger?.error("Failed to perform automatic configuration: \(error, privacy: .public)")
+      VitalLogger.core.error("Failed to perform automatic configuration: \(error, privacy: .public)")
     }
   }
   
@@ -303,13 +302,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
     updateAPIClientConfiguration: (inout APIClient.Configuration) -> Void = { _ in }
   ) {
     
-    var logger: Logger?
-    
-    if configuration.logsEnable {
-      logger = Logger(subsystem: "vital", category: "vital-network-client")
-    }
-    
-    logger?.info("VitalClient setup for environment \(String(describing: environment), privacy: .public)")
+    VitalLogger.core.info("VitalClient setup for environment \(String(describing: environment), privacy: .public)")
 
     let authStrategy: VitalClientAuthStrategy
 
@@ -322,7 +315,6 @@ let user_secureStorageKey: String = "user_secureStorageKey"
 
     let apiClientDelegate = VitalClientDelegate(
       environment: environment,
-      logger: logger,
       authStrategy: authStrategy
     )
 
@@ -339,11 +331,10 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       try secureStorage.set(value: securePayload, key: core_secureStorageKey)
     }
     catch {
-      logger?.info("We weren't able to securely store VitalCoreSecurePayload: \(error, privacy: .public)")
+      VitalLogger.core.info("We weren't able to securely store VitalCoreSecurePayload: \(error, privacy: .public)")
     }
     
     let coreConfiguration = VitalCoreConfiguration(
-      logger: logger,
       apiVersion: apiVersion,
       apiClient: apiClient,
       environment: environment,
@@ -382,7 +373,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       }
     }
     catch {
-      configuration.logger?.info("We weren't able to get the stored userId VitalCoreSecurePayload: \(error, privacy: .public)")
+      VitalLogger.core.info("We weren't able to get the stored userId VitalCoreSecurePayload: \(error, privacy: .public)")
     }
     
     self.apiKeyModeUserId.set(value: newUserId)
@@ -391,7 +382,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       try secureStorage.set(value: newUserId, key: user_secureStorageKey)
     }
     catch {
-      configuration.logger?.info("We weren't able to securely store VitalCoreSecurePayload: \(error, privacy: .public)")
+      VitalLogger.core.info("We weren't able to securely store VitalCoreSecurePayload: \(error, privacy: .public)")
     }
   }
 

--- a/Sources/VitalCore/Core/Client/VitalClientDelegates.swift
+++ b/Sources/VitalCore/Core/Client/VitalClientDelegates.swift
@@ -8,16 +8,13 @@ enum VitalClientAuthStrategy {
 
 class VitalClientDelegate: APIClientDelegate {
   private let environment: Environment
-  private let logger: Logger?
   private let authStrategy: VitalClientAuthStrategy
 
   init(
     environment: Environment,
-    logger: Logger? = nil,
     authStrategy: VitalClientAuthStrategy
   ) {
     self.environment = environment
-    self.logger = logger
     self.authStrategy = authStrategy
   }
   
@@ -72,7 +69,7 @@ class VitalClientDelegate: APIClientDelegate {
       payload: data
     )
         
-    self.logger?.error("Failed request with error: \(networkError, privacy: .public)")
+    VitalLogger.core.error("Failed request with error: \(networkError, privacy: .public)")
     throw networkError
   }
 }

--- a/Sources/VitalCore/Core/Logs/VitalLogger.swift
+++ b/Sources/VitalCore/Core/Logs/VitalLogger.swift
@@ -1,0 +1,8 @@
+import OSLog
+
+public enum VitalLogger {
+  public static let subsystem = "io.tryvital.vital-ios"
+
+  public static let core = Logger(subsystem: Self.subsystem, category: "core")
+  public static let healthKit = Logger(subsystem: Self.subsystem, category: "core")
+}

--- a/Sources/VitalCore/Core/Logs/VitalLogger.swift
+++ b/Sources/VitalCore/Core/Logs/VitalLogger.swift
@@ -4,5 +4,5 @@ public enum VitalLogger {
   public static let subsystem = "io.tryvital.vital-ios"
 
   public static let core = Logger(subsystem: Self.subsystem, category: "core")
-  public static let healthKit = Logger(subsystem: Self.subsystem, category: "core")
+  public static let healthKit = Logger(subsystem: Self.subsystem, category: "healthKit")
 }

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -1050,7 +1050,7 @@ func queryActivityDaySummaries(
     ... calendar.floatingDate(of: endTime)
   let queryInterval = calendar.timeRange(of: datesToCompute)
 
-  logger?.info("""
+  VitalLogger.healthKit.info("""
   [Day Summary] lastComputed = \(startTime, privacy: .public) now = \(endTime, privacy: .public)
   datesToCompute = \(datesToCompute.lowerBound, privacy: .public) ... \(datesToCompute.upperBound, privacy: .public)
   queryInterval = \(queryInterval.lowerBound, privacy: .public) ..< \(queryInterval.upperBound, privacy: .public)


### PR DESCRIPTION
Apple DTS advice:

> https://developer.apple.com/forums/thread/705868
>
> Logging is fast enough to leave log points [1] enabled in your release build, which makes it easier to debug issues that only show up in the field.

For production (TestFlight and App Store) apps, critical/error/default logs are persisted (with OS managed log rotation), info logs are only kept in memory, and debug logs are dropped. Given that our log frequency is also fairly sparse, it would be way easier if we just have an always-on logging setup (provided that we use the log levels appropriately).

----

Simplify our logging setup by:

1. creating a set of static `OSLog.Logger`s (namespaces under the `VitalLogger` enum), which can be used from any scope/context. 

3. unconditionally log to OSLog; effectively deprecating `logsEnabled` settings on the SDK configuration methods.

4. Use reverse domain name as OSLog subsystem, to match platform conventions.