### PR TITLE
[VIT-2682] Always call HealthKit completion handlers.

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -228,7 +228,9 @@ extension VitalHealthKitClient {
         // Any buffered payload would not be processed, and is expected to be redelivered by
         // HealthKit.
         //
-        // https://developer.apple.com/documentation/healthkit/hkhealthstore/1614175-enablebackgrounddelivery
+        // > https://developer.apple.com/documentation/healthkit/hkhealthstore/1614175-enablebackgrounddelivery#3801028
+        // > If you don’t call the update’s completion handler, HealthKit continues to attempt to
+        // > launch your app using a backoff algorithm to increase the delay between attempts.
         try Task.checkCancellation()
 
         // Task is not cancelled — we must call the HealthKit completion handler irrespective of

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -251,9 +251,9 @@ extension VitalHealthKitClient {
         if payload.sampleTypes.count > 1 {
         /// This means we are trying to sync related samples, so let's convert it to a `VitalResource`
           let resource = store.toVitalResource(first)
-          await sync(payload: .resource(resource), completion: payload.completion)
+          await sync(payload: .resource(resource))
         } else {
-          await sync(payload: .type(first), completion: payload.completion)
+          await sync(payload: .type(first))
         }
       }
     }
@@ -378,7 +378,7 @@ extension VitalHealthKitClient {
   public func syncData(for resources: [VitalResource]) {
     Task(priority: .high) {
       for resource in resources {
-        await sync(payload: .resource(resource), completion: {})
+        await sync(payload: .resource(resource))
       }
       
       _status.send(.syncingCompleted)
@@ -439,8 +439,7 @@ extension VitalHealthKitClient {
   }
   
   private func sync(
-    payload: SyncPayload,
-    completion: () -> Void
+    payload: SyncPayload
   ) async {
     
     let configuration = await configuration.get()
@@ -524,10 +523,6 @@ extension VitalHealthKitClient {
       
       // Signal success
       _status.send(.successSyncing(resource, data))
-      
-      /// Call completion
-      completion()
-      
     }
     catch let error {
       // Signal failure


### PR DESCRIPTION
Always call HealthKit completion handlers, no matter whether the sync has failed or not.

If the phone has undesirable network condition [1] for an extensive period of time, it is currently possible for our SDK to fail to respond in background (by calling HealthKit completion handlers) 3 times in a row, and subsequently gets kicked off the background delivery list by HealthKit.

This is because we only call the HealthKit completion handlers on the happy "sync completed" path.

> https://developer.apple.com/documentation/healthkit/hkhealthstore/1614175-enablebackgrounddelivery
> If your app fails to respond three times, HealthKit assumes your app can’t receive data and stops sending background updates.

Make sure that:

1. the HealthKit completion handler is always called, regardless of the triggered Vital sync has completed or failed.

1. `backgroundDeliveryTask` stops properly when cancellation is requested.

Also log both the HealthKit call itself, and the dequeuing of `BackgroundDeliveryPayload`.


<sup>[1]</sup>  e.g., offline during Tube journey, offline for a few days, or just bad reception