### PR TITLE
[VIT-2687] Serialize SDK singleton accessors.

### DIFF
--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -124,6 +124,11 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       return value
     }
   }
+
+  // @testable
+  internal static func setClient(_ client: VitalClient?) {
+    clientInitLock.withLock { Self.client = client }
+  }
   
   /// Only use this method if you are working from Objc.
   /// Please use the async/await configure method when working from Swift.


### PR DESCRIPTION
The singleton accessor is not serialized by a lock. So when it is accessed on multiple threads, especially during app launches, a race condition exists and causes multiple instances to be initialised and configured.

In one instance, `VitalClient.configure` intermittently sees a different `VitalClient` instance as to what a subsequent `VitalClient.setUserId` call sees, and this scenario is more prone to happen when there are other async calls in between any access to `VitalClient.shared` (where the current task may suspend and resume on a different thread). This causes the latter to crash, because the former sets the configuration on a different instance that the latter has no access to.

Protect the `shared` accessor with a lock, so only one instance can be created.


---

Also remove the deprecation message on the async `configure(3)` overloads for now, since Swift compiler still does not pick the synchronous overload despite deprecation of the async overload. It instead continues to warn about "missing await keyword". We may consider removing them in a future major API breaking release.
