### PR TITLE
Use HKStatCollectionQuery for day summaries

### DIFF
--- a/Sources/VitalCore/Calendar/GregorianCalendar.swift
+++ b/Sources/VitalCore/Calendar/GregorianCalendar.swift
@@ -12,14 +12,14 @@ public struct GregorianCalendar {
   }
 
   /// End inclusive
-  public func enumerate(_ lowerBound: FloatingDate, _ upperBound: FloatingDate) -> [FloatingDate] {
-    guard lowerBound != upperBound else {
+  public func enumerate(_ dateRange: ClosedRange<FloatingDate>) -> [FloatingDate] {
+    guard dateRange.lowerBound != dateRange.upperBound else {
       // range.lowerBound == range.upperBound
-      return [lowerBound]
+      return [dateRange.lowerBound]
     }
 
-    let endTime = startOfDay(upperBound)
-    var startTime = startOfDay(lowerBound)
+    let endTime = startOfDay(dateRange.upperBound)
+    var startTime = startOfDay(dateRange.lowerBound)
     precondition(startTime < endTime)
 
     var results = [FloatingDate]()
@@ -49,6 +49,15 @@ public struct GregorianCalendar {
       Self.invariantViolation()
     }
     return startOfDay
+  }
+
+  /// Return an end-exclusive UTC time range that would cover the given closed range of calendar dates with respect to `self`.
+  public func timeRange(of dateRange: ClosedRange<FloatingDate>) -> Range<Date> {
+    // Since we are returning an end-exclusive UTC time range, the upper bound is the first instant
+    // of the day after the end date.
+    let dayAfterEndDate = offset(dateRange.upperBound, byDays: 1)
+
+    return startOfDay(dateRange.lowerBound) ..< startOfDay(dayAfterEndDate)
   }
 
   public func offset(_ date: FloatingDate, byDays days: Int) -> FloatingDate {

--- a/Tests/VitalCoreTests/GregorianCalendarTests.swift
+++ b/Tests/VitalCoreTests/GregorianCalendarTests.swift
@@ -5,6 +5,8 @@ import XCTest
 class GregorianCalendarTests: XCTestCase {
   typealias FloatingDate = GregorianCalendar.FloatingDate
 
+  let calendar = GregorianCalendar(timeZone: TimeZone(identifier: "Asia/Tokyo")!)
+
   func test_floating_date_ordering() {
     XCTAssertFalse(FloatingDate(year: 2023, month: 2, day: 3) < FloatingDate(year: 2023, month: 2, day: 3))
     XCTAssertEqual(FloatingDate(year: 2023, month: 2, day: 3), FloatingDate(year: 2023, month: 2, day: 3))
@@ -32,5 +34,54 @@ class GregorianCalendarTests: XCTestCase {
     // day, month and year component
     XCTAssertTrue(FloatingDate(year: 2023, month: 4, day: 16) < FloatingDate(year: 2030, month: 7, day: 31))
     XCTAssertFalse(FloatingDate(year: 2023, month: 4, day: 16) < FloatingDate(year: 2003, month: 3, day: 18))
+  }
+
+  func test_timeRange_multiple_dates() throws {
+    let dateRange = try XCTUnwrap(FloatingDate("2023-01-23")) ... XCTUnwrap(FloatingDate("2023-01-26"))
+    let timeRange = calendar.timeRange(of: dateRange)
+
+    // 2023-01-22 15:00:00 UTC
+    XCTAssertEqual(timeRange.lowerBound, Date(timeIntervalSince1970: 1674399600))
+
+    // 2023-01-26 15:00:00 UTC
+    XCTAssertEqual(timeRange.upperBound, Date(timeIntervalSince1970: 1674745200))
+  }
+
+  func test_timeRange_single_date() throws {
+    let dateRange = try XCTUnwrap(FloatingDate("2023-01-23")) ... XCTUnwrap(FloatingDate("2023-01-23"))
+    let timeRange = calendar.timeRange(of: dateRange)
+
+    // 2023-01-22 15:00:00 UTC
+    XCTAssertEqual(timeRange.lowerBound, Date(timeIntervalSince1970: 1674399600))
+
+    // 2023-01-23 15:00:00 UTC
+    XCTAssertEqual(timeRange.upperBound, Date(timeIntervalSince1970: 1674486000))
+  }
+
+  func test_enumerate_multiple_dates() throws {
+    let dateRange = try XCTUnwrap(FloatingDate("2023-01-23")) ... XCTUnwrap(FloatingDate("2023-01-26"))
+    let dates = calendar.enumerate(dateRange)
+
+    try XCTAssertEqual(
+      dates,
+      [
+        XCTUnwrap(FloatingDate("2023-01-23")),
+        XCTUnwrap(FloatingDate("2023-01-24")),
+        XCTUnwrap(FloatingDate("2023-01-25")),
+        XCTUnwrap(FloatingDate("2023-01-26"))
+      ]
+    )
+  }
+
+  func test_enumerate_single_date() throws {
+    let dateRange = try XCTUnwrap(FloatingDate("2023-01-23")) ... XCTUnwrap(FloatingDate("2023-01-23"))
+    let dates = calendar.enumerate(dateRange)
+
+    try XCTAssertEqual(
+      dates,
+      [
+        XCTUnwrap(FloatingDate("2023-01-23")),
+      ]
+    )
   }
 }

--- a/Tests/VitalHealthKitTests/VitalHealthKitReadsTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitReadsTests.swift
@@ -200,26 +200,26 @@ class VitalHealthKitReadsTests: XCTestCase {
     let date = Date()
     let (startDate, endDate) = (Date.dateAgo(date, days: 30), date)
 
-    var dateRanges: [ClosedRange<Date>] = []
+    var dateRanges: [Range<Date>] = []
     
-    debug.executeHourlyStatisticalQuery = { type, queryStartDate, queryEndDate, handler in
+    debug.executeStatisticalQuery = { type, queryInterval, granularity in
       XCTAssertEqual(quantityType, type)
+      XCTAssertEqual(granularity, .hourly)
 
-      let range = queryStartDate ... queryEndDate
-      dateRanges.append(range)
+      dateRanges.append(queryInterval)
       
       if dateRanges.count == 1 {
-        XCTAssert(range.contains(startDate) == false)
-        XCTAssert(range.contains(endDate) == false)
+        XCTAssert(queryInterval.contains(startDate) == false)
+        XCTAssert(queryInterval.contains(endDate) == false)
       }
       
       if dateRanges.count == 2 {
-        XCTAssert(range.contains(startDate) == false)
-        XCTAssert(range.contains(endDate) == true)
+        XCTAssert(queryInterval.contains(startDate) == false)
+        XCTAssert(queryInterval.contains(endDate) == false)
       }
       
       let element = vitalStastics.removeFirst()
-      handler(.success(element))
+      return element
     }
 
     debug.getFirstAndLastSampleTime = { type, start, end in
@@ -283,24 +283,24 @@ class VitalHealthKitReadsTests: XCTestCase {
     let date = Date()
     let (startDate, endDate) = (Date.dateAgo(date, days: 30), date)
 
-    var dateRanges: [ClosedRange<Date>] = []
+    var dateRanges: [Range<Date>] = []
 
     debug.getFirstAndLastSampleTime = { type, start, end in
       XCTAssertEqual(quantityType, type)
       return nil
     }
     
-    debug.executeHourlyStatisticalQuery = { type, queryStartDate, queryEndDate, handler in
+    debug.executeStatisticalQuery = { type, queryInterval, granularity in
       XCTAssertEqual(quantityType, type)
+      XCTAssertEqual(granularity, .hourly)
 
-      let range = queryStartDate ... queryEndDate
+      XCTAssert(queryInterval.contains(startDate) == true)
+      XCTAssert(queryInterval.contains(endDate) == false)
       
-      XCTAssert(range.contains(startDate) == true)
-      XCTAssert(range.contains(endDate) == true)
-      
-      dateRanges.append(range)
+      dateRanges.append(queryInterval)
+
       let element = vitalStastics.removeFirst()
-      handler(.success(element))
+      return element
     }
     
     debug.isLegacyType = { type in


### PR DESCRIPTION
Turns out that HKStatisticsQuery does not produce the same aggregation results as HKStatCollectionQuery, even when both are logically working on the exact same unit of time.

Since the results of HKStatCollectionQuery are what exactly matches the Apple Health app, adopt HKStatCollectionQuery for day summary.


#### Changes

1. Removed the now-disused `executeDaySummaryQuery` and `executeSampleQuery`.

2. Refactored `executeStatisticalQuery` so that it can support both hourly and daily granularity. It is also reworked to be an (cancellable) async function.

3. Tweaked how we query and put together the day summaries.

    * For each quantity type, we now use only 1 `executeStatisticalQuery` call to cover the whole date range.
    * All sums are rounded down to match Apple Health app behaviour.

7. Added some utilities and unit test coverage to `VitalCore.GregorianCalendar`.