### PR TITLE
[VIT-2714] Check task cancellation before submitting HKQuery

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -363,6 +363,14 @@ struct StatisticsQueryDependencies {
           query.initialResultsHandler = { query, collection, error in
             handle(query, collection: collection, error: error, continuation: continuation)
           }
+
+          // HealthKit raises an Objective-C exception if one attempts to execute a stopped query.
+          // So check cancellation proactively before we proceed.
+          guard Task.isCancelled == false else {
+            continuation.resume(throwing: CancellationError())
+            return
+          }
+
           healthKitStore.execute(query)
         }
       } onCancel: {

--- a/Tests/VitalHealthKitTests/StatisticalQueryTests.swift
+++ b/Tests/VitalHealthKitTests/StatisticalQueryTests.swift
@@ -1,0 +1,27 @@
+import HealthKit
+import VitalCore
+@testable import VitalHealthKit
+import XCTest
+
+class StatisticalQueryTests: XCTestCase {
+
+  func test_respects_cooperative_cancellation() async {
+    let dependencies = StatisticsQueryDependencies.live(healthKitStore: HKHealthStore(), vitalStorage: VitalHealthKitStorage(storage: .debug))
+
+    // Run it 100 times to mitigate away any temporary blips that might cause it to pass.
+    for _ in 0 ..< 100 {
+      let task = Task {
+        _ = try await dependencies.executeStatisticalQuery(
+          HKQuantityType.quantityType(forIdentifier: .stepCount)!,
+          Date().addingTimeInterval(-86400) ..< Date(),
+          .daily
+        )
+
+        XCTFail("Unexpected return")
+      }
+
+      task.cancel()
+      _ = await task.result
+    }
+  }
+}

--- a/Tests/VitalHealthKitTests/VitalHealthKitStorageTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitStorageTests.swift
@@ -9,7 +9,7 @@ class VitalHealthKitStorageTests: XCTestCase {
   override func tearDown() {
     VitalHealthKitStorage(storage: .debug).remove(key: "key")
   }
-  
+
   func testAnchorStorage() throws {
     let storage = VitalHealthKitStorage(storage: .debug)
     let key = "key"


### PR DESCRIPTION
Sentry flagged

Swift's semantic of its `withTaskCancellationHandler` primitive appears to be running the cancellation handler immediately on cancellation, no matter whether or not the main operation body has been executed.

This creates a scenario where — if `executeStatisticalQuery` is marked as cancelled before it gets executed — we would be attempting to ask HKHealthStore to start a stopped HKQuery, causing an NSInvalidArgumentException.

Check `Task.isCancelled` before we submit the `HKStatisticsCollectionQuery` to HKHealthStore to avoid this scenario.