### PR TITLE
[VIT-2715] Use HKStatQuery for first & last sample time

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -1013,14 +1013,13 @@ func enrichWithDates(
   return try await withThrowingTaskGroup(of: VitalStatistics.self) { group in
     for entry in statistics {
       group.addTask {
-        let result = try await dependencies.getFirstAndLastSampleTime(
+        let sampleTimeRange = try await dependencies.getFirstAndLastSampleTime(
           entry.type,
-          entry.startDate,
-          entry.endDate
+          entry.startDate ..< entry.endDate
         )
 
-        if let (first, last) = result {
-          return entry.withSampleDates(first: first, last: last)
+        if let range = sampleTimeRange {
+          return entry.withSampleDates(first: range.lowerBound, last: range.upperBound)
         } else {
           return entry
         }

--- a/Tests/VitalHealthKitTests/VitalHealthKitReadsTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitReadsTests.swift
@@ -222,7 +222,7 @@ class VitalHealthKitReadsTests: XCTestCase {
       return element
     }
 
-    debug.getFirstAndLastSampleTime = { type, start, end in
+    debug.getFirstAndLastSampleTime = { type, _ in
       XCTAssertEqual(quantityType, type)
 
       return nil
@@ -285,7 +285,7 @@ class VitalHealthKitReadsTests: XCTestCase {
 
     var dateRanges: [Range<Date>] = []
 
-    debug.getFirstAndLastSampleTime = { type, start, end in
+    debug.getFirstAndLastSampleTime = { type, _ in
       XCTAssertEqual(quantityType, type)
       return nil
     }


### PR DESCRIPTION
To address VIT-2715 further, drop our ad-hoc HKSampleQuery-based solution for seeking first & last sample time for something better.

It turns out that HKStatisticsQuery produces the exact information we are looking for here:

> https://developer.apple.com/documentation/healthkit/hkstatistics/1615351-startdate
> If you calculated these statistics using a statistics query, this is the **earliest start date from all the samples** that match the query.

> https://developer.apple.com/documentation/healthkit/hkstatistics/1615067-enddate
> If you calculated these statistics using a statistics query, this is the **latest end date from all the samples** that match the query.

So switch `getFirstAndLastSampleTime` over to use HKStatisticsQuery, and eliminate the offending invariant check altogether.

As a bonus, the result turnaround time seems to be generally 1.5-2x faster than the current two-query solution in synthetic test. It could be a result of HealthKit throttling the # of concurrent queries, or that HKStatisticsQuery has a optimised implementation.