### PR TITLE
[wip] Improve compatibility with HKWorkoutSession workouts

### DIFF
--- a/Sources/VitalHealthKit/Extensions/Array.swift
+++ b/Sources/VitalHealthKit/Extensions/Array.swift
@@ -17,3 +17,18 @@ extension Array where Element == HKSample {
     }
   }
 }
+
+extension Collection where Element: OptionalProtocol {
+  func filterNotNil() -> [Element.Wrapped] {
+    compactMap { $0.wrapped }
+  }
+}
+
+internal protocol OptionalProtocol {
+  associatedtype Wrapped
+  var wrapped: Wrapped? { get }
+}
+
+extension Optional: OptionalProtocol {
+  internal var wrapped: Wrapped? { self }
+}

--- a/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
@@ -420,15 +420,11 @@ public extension SleepPatch.Sleep {
 }
 
 extension WorkoutPatch.Workout {
-  public init?(sample: HKSample) {
-    guard let workout = sample as? HKWorkout else {
-      return nil
-    }
-        
+  public init(workout: HKWorkout) {
     self.init(
       id: workout.uuid,
-      startDate: sample.startDate,
-      endDate: sample.endDate,
+      startDate: workout.startDate,
+      endDate: workout.endDate,
       sourceBundle: workout.sourceRevision.source.bundleIdentifier,
       productType: workout.sourceRevision.productType,
       sport: workout.workoutActivityType.toString,


### PR DESCRIPTION
Third-party workout apps typically use `HKWorkoutSession` to record workout on Apple Watch.

In the first-party Exercise app, both the resulting `HKWorkout` and all automatically collected samples (e.g. heart rate) are attributed to the Apple Watch's prefixed UUID (`com.apple.health.<UUID>`) as their `HKSource`.

This is not the case for third-party apps — the resulting `HKWorkout` would be attributed to the third-party app instead (e.g., `com.cameronchow.Strong`) This means our current workout heart rate sample query would return no result, if the workout is recorded by `HKWorkoutSession` but not through the first-party Exercise app.

This PR:

* Update the workout heart rate sample query to improve compatibility with HKWorkoutSession workouts from third-party apps.
* Remove the workout respiratory rate query, since it is only collected during sleep sessions.