### PR TITLE
[VIT-2799] Disconnect peripheral on read completion

### DIFF
--- a/Sources/VitalDevices/DeviceReading/GATTMeter.swift
+++ b/Sources/VitalDevices/DeviceReading/GATTMeter.swift
@@ -73,6 +73,10 @@ internal class GATTMeter<Sample> {
             },
             receiveCompletion: { _ in
               cancellables.forEach { $0.cancel() }
+
+              // Disconnect when we have done reading. Some devices rely on BLE disconnection as
+              // a cue to toast users with a "Transferred Completed" message.
+              self.manager.cancelPeripheralConnection(peripheral)
             },
             receiveCancel: {
               cancellables.forEach { $0.cancel() }


### PR DESCRIPTION
Accu-Check appears to rely on BLE disconnection as a cue of transfer being completed, and users are prompted accordingly.

To make sure that this happens consistently, cancel the connection whenever we have completed a reading. Each `read()` call will attempt to reconnect from scratch anyway, so the cancellation should not be a concern for repeated calls (for whatever legitimate reasons).

Though note that the disconnection takes a few seconds to take effect, and it appears to be out of our control. The ball is in Core Bluetooth's court.

---

Also updated the iOS example app to separate the scanning and pair-n-read stage. By separating them, it also now supports re-reading from the device by tapping the button again.

<img src="https://user-images.githubusercontent.com/11806295/230425757-7d296cd2-72fc-406d-9947-0d051947d291.PNG" width="300" />
