### PR TITLE
[VIT-2891] Use a separate resource mapping for background observers.

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -205,11 +205,8 @@ extension VitalHealthKitClient {
     /// If it's already running, cancel it
     self.backgroundDeliveryTask?.cancel()
     
-    let allowedSampleTypes = Set(resources.flatMap(toHealthKitTypes(resource:)))
-
-    let set: [Set<HKObjectType>] = observedSampleTypes().map(Set.init)
-    let common: [[HKSampleType]] = set.map { $0.intersection(allowedSampleTypes) }.map { $0.compactMap { $0 as? HKSampleType } }
-    let cleaned: Set<[HKSampleType]> = Set(common.filter { $0.isEmpty == false })
+    let sampleTypesToObserve = Set(resources.map(sampleTypesToTriggerSync(for:)))
+    let cleaned: Set<Set<HKSampleType>> = Set(sampleTypesToObserve.filter { $0.isEmpty == false })
 
     let uniqueFlatenned: Set<HKSampleType> = Set(cleaned.flatMap { $0 })
 
@@ -283,7 +280,7 @@ extension VitalHealthKitClient {
 
   @available(iOS 15.0, *)
   private func bundledBackgroundObservers(
-    for typesBundle: Set<[HKSampleType]>
+    for typesBundle: Set<Set<HKSampleType>>
   ) -> AsyncStream<BackgroundDeliveryPayload> {
 
     return AsyncStream<BackgroundDeliveryPayload> { continuation in


### PR DESCRIPTION
Part 1 of 3(?) for VIT-2889

We currently create `HKObserverQuery` with each & every sample type that would be used by a `VitalResource`. This is unnecessary for `HKWorkout` and sleep sessions (reconstructed from `HKCategorySample`s).

For example, a workout session might embed heart rate and respiratory rate samples. But we need not require any insertion of these types to trigger HKWorkout sync, since generally speaking all the relevant HR/RR samples during the session would have already been written before the HKWorkout is eventually finalized and written. So we can simply fetch these samples w/o requiring an HKHealthStore observation to drive the process.