### PR TITLE
[VIT-2892] Introduce VitalHealthKitStore.permittedResources (2/4)

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -151,7 +151,7 @@ internal var logger: Logger? {
     if backgroundDeliveryEnabled.value != true {
       backgroundDeliveryEnabled.set(value: true)
       
-      let resources = resourcesAskedForPermission(store: self.store)
+      let resources = Array(self.store.permittedResources())
       checkBackgroundUpdates(isBackgroundEnabled: configuration.backgroundDeliveryEnabled, resources: resources)
     }
   }
@@ -380,7 +380,7 @@ extension VitalHealthKitClient {
   }
   
   public func syncData() {
-    let resources = resourcesAskedForPermission(store: store)
+    let resources = Array(store.permittedResources())
     syncData(for: resources)
   }
   
@@ -593,25 +593,11 @@ extension VitalHealthKitClient {
 
 extension VitalHealthKitClient {
   public static func read(resource: VitalResource, startDate: Date, endDate: Date) async throws -> ProcessedResourceData? {
-    let store = HKHealthStore()
-    
-    let hasAskedForPermission: (VitalResource) -> Bool = { resource in
-      return toHealthKitTypes(resource: resource)
-        .map { store.authorizationStatus(for: $0) != .notDetermined }
-        .reduce(true, { $0 && $1})
-    }
-    
-    let toVitalResource: (HKSampleType) -> VitalResource = { type in
-      return VitalHealthKitStore.sampleTypeToVitalResource(hasAskedForPermission: hasAskedForPermission, type: type)
-    }
-    
-    let (data, _): (ProcessedResourceData?, [StoredAnchor]) = try await VitalHealthKit.read(
-      resource: resource,
-      healthKitStore: store,
-      typeToResource: toVitalResource,
-      vitalStorage: VitalHealthKitStorage(storage: .debug),
-      startDate: startDate,
-      endDate: endDate
+    let (data, _) = try await VitalHealthKitClient.shared.store.readResource(
+      resource,
+      startDate,
+      endDate,
+      VitalHealthKitStorage(storage: .debug)
     )
 
     if let data = data {


### PR DESCRIPTION
* Moved `resourcesAskedForPermission(1)` into `VitalHealthKitStore`, and renamed it to `permittedResources()`.

* Introducing `remapResource(2)` for `VitalResource` remapping for the body & activity special cases.

   * This performs the same VitalResource remapping as `VitalHealthKitStore.sampleTypeToVitalResource(2)` (the crash location), but operates at the `VitalResource` level instead. The final PR addressing the crash will remove all kinds of brittle (and sometimes ambiguous) HKSampleType -> VitalResource reverse mapping in our SDK altogether.
 

    * As a bonus, any missing new `VitalResource` case will be flagged here thanks to the default exhaustiveness checking.

* Updated `VitalHealthKitClient.read` and `VitalHealthKitStore.live.readResource`, so that they all honour the resource remapping in `remapResource(2)`