### PR TITLE
[VIT-2893] Refactor individual resource reading (3/4)

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -135,7 +135,6 @@ extension VitalHealthKitStore {
       try await read(
         resource: resource,
         healthKitStore: store,
-        typeToResource: toVitalResource,
         vitalStorage: storage,
         startDate: startDate,
         endDate: endDate

--- a/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
@@ -1,40 +1,31 @@
 import HealthKit
 import VitalCore
 
+func toHealthKitTypes(individualResource: VitalResource.Individual) -> HKSampleType {
+  switch individualResource {
+  case .steps:
+    return HKSampleType.quantityType(forIdentifier: .stepCount)!
+  case .activeEnergyBurned:
+    return HKSampleType.quantityType(forIdentifier: .activeEnergyBurned)!
+  case .basalEnergyBurned:
+    return HKSampleType.quantityType(forIdentifier: .basalEnergyBurned)!
+  case .floorsClimbed:
+    return HKSampleType.quantityType(forIdentifier: .flightsClimbed)!
+  case .distanceWalkingRunning:
+    return HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!
+  case .vo2Max:
+    return HKSampleType.quantityType(forIdentifier: .vo2Max)!
+  case .weight:
+    return HKSampleType.quantityType(forIdentifier: .bodyMass)!
+  case .bodyFat:
+    return HKSampleType.quantityType(forIdentifier: .bodyFatPercentage)!
+  }
+}
+
 func toHealthKitTypes(resource: VitalResource) -> Set<HKObjectType> {
   switch resource {
-    case .individual(.steps):
-      return [
-        HKSampleType.quantityType(forIdentifier: .stepCount)!,
-      ]
-    case .individual(.activeEnergyBurned):
-      return [
-        HKSampleType.quantityType(forIdentifier: .activeEnergyBurned)!,
-      ]
-    case .individual(.basalEnergyBurned):
-      return [
-        HKSampleType.quantityType(forIdentifier: .basalEnergyBurned)!,
-      ]
-    case .individual(.floorsClimbed):
-      return [
-        HKSampleType.quantityType(forIdentifier: .flightsClimbed)!,
-      ]
-    case .individual(.distanceWalkingRunning):
-      return [
-        HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!,
-      ]
-    case .individual(.vo2Max):
-      return [
-        HKSampleType.quantityType(forIdentifier: .vo2Max)!,
-      ]
-    case .individual(.weight):
-      return [
-        HKSampleType.quantityType(forIdentifier: .bodyMass)!,
-      ]
-    case .individual(.bodyFat):
-      return [
-        HKSampleType.quantityType(forIdentifier: .bodyFatPercentage)!,
-      ]
+    case let .individual(resource):
+      return [toHealthKitTypes(individualResource: resource)]
       
     case .profile:
       return [

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -594,21 +594,10 @@ extension VitalHealthKitClient {
 extension VitalHealthKitClient {
   public static func read(resource: VitalResource, startDate: Date, endDate: Date) async throws -> ProcessedResourceData? {
     let store = HKHealthStore()
-    
-    let hasAskedForPermission: (VitalResource) -> Bool = { resource in
-      return toHealthKitTypes(resource: resource)
-        .map { store.authorizationStatus(for: $0) != .notDetermined }
-        .reduce(true, { $0 && $1})
-    }
-    
-    let toVitalResource: (HKSampleType) -> VitalResource = { type in
-      return VitalHealthKitStore.sampleTypeToVitalResource(hasAskedForPermission: hasAskedForPermission, type: type)
-    }
-    
+
     let (data, _): (ProcessedResourceData?, [StoredAnchor]) = try await VitalHealthKit.read(
       resource: resource,
       healthKitStore: store,
-      typeToResource: toVitalResource,
       vitalStorage: VitalHealthKitStorage(storage: .debug),
       startDate: startDate,
       endDate: endDate


### PR DESCRIPTION
Refactor individual resource reading, so that a reverse HKSampleType -> VitalResource mapping (where the crash happens) is no longer required as part of the read process.

As a bonus point, any missing new `VitalResource.Individual` case will now be alerted on `readIndividual(5)` thanks to the default exhaustiveness checking. This also eliminated two `fatalError` crash-and-burn paths we've had in our read process.