### PR TITLE
[VIT-2889] Remove the brittle reverse HKSampleType->VitalResource mapping (4/4)

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Models/BackgroundDeliveryPayload.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/BackgroundDeliveryPayload.swift
@@ -1,6 +1,7 @@
 import HealthKit
+import VitalCore
 
 struct BackgroundDeliveryPayload {
-  let sampleTypes: Set<HKSampleType>
+  let resource: VitalResource
   let completion: () -> Void
 }

--- a/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
@@ -65,7 +65,6 @@ func toHealthKitTypes(resource: VitalResource) -> Set<HKObjectType> {
       ]
 
     case .body:
-      
       return toHealthKitTypes(resource: .individual(.bodyFat)) +
       toHealthKitTypes(resource: .individual(.weight))
       


### PR DESCRIPTION
Eliminate the brittle HKSampleType -> VitalResource mapping altogether (the site of some of the crashes).

* Each `HKObserverQuery` created now captures its designated `VitalResource`, so reverse mapping is no longer necessary.

* Remove the reverse mapping (available via `sampleTypeToVitalResource(2)` and `VitalHealthKitStore.toVitalResource`).