### PR TITLE
[VIT-2888] Stop crashing in setUserID when the SDK is not yet configured.

### DIFF
--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+User.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+User.swift
@@ -44,7 +44,7 @@ public extension VitalClient.User {
     let value = try await configuration.apiClient.send(request).value
     
     if setUserIdOnSuccess {
-      await VitalClient.setUserId(value.userId)
+      try VitalClient.setUserID(value.userId)
     }
     
     return value

--- a/Tests/VitalHealthKitTests/VitalHealthKitClientTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitClientTests.swift
@@ -17,7 +17,7 @@ class VitalHealthKitClientTests: XCTestCase {
   
   func testAskingForPermissionsContinuesWithoutAuthentication() async {
     
-    await VitalClient.shared.cleanUp()
+    VitalClient.shared.reset()
     let value = VitalHealthKitClient(store: .debug)
     
     _ = value.hasAskedForPermission(resource: .body)


### PR DESCRIPTION
* `VitalClient.automaticConfiguration` should not attempt to set userID if it did not manage to recover a previous SDK configuration.

* `setUserID` now throws an `VitalClientError` when the SDK is not yet configured, instead of crashing with `fatalError()`.

* The completion block of `automaticConfiguration(completion:)` for both VitalClient and VitalHealthKitClient now gain an optional `Error?` parameter.

* `setUserID()` and `reset()`  (previously `setUserId()` and `cleanUp()`) are now synchronous calls.

   * This should mitigate the suspected cause in https://github.com/tryVital/vital-react-native/issues/29, where cleanUp() is called from a scenario that does not support asynchronous calls (e.g., React cleanup function), and therefore cannot defer any potential subsequent SDK usage to wait for the cleanUp() calls to complete. The mitigation works by eliminating any potential thread/executor hop, since a synchronous function must be executed in place.

   * The renaming is unavoidable, since Swift always picks the async version when resolving overloads in an async context. This means the synchronous version would never be properly selected if it continues to share the base signature with the async function being replaced.