### PR TITLE
[VIT-2890] Mitigate Range<Date> precondition failure

### DIFF
--- a/Sources/VitalHealthKit/Extensions/Date.swift
+++ b/Sources/VitalHealthKit/Extensions/Date.swift
@@ -11,9 +11,9 @@ extension Date {
   
   static func dateAgo(_ date: Date = .init(), days: Int) -> Date {
     let daysAgoDate = vitalCalendar.date(byAdding: .day, value: -abs(days), to: date)
-    let beginningOfTheDay = daysAgoDate?.dayStart
+    let beginningOfTheDay = daysAgoDate!.dayStart
     
-    return beginningOfTheDay ?? date
+    return beginningOfTheDay
   }
   
   var dateComponentsForActivityQuery: DateComponents {


### PR DESCRIPTION
It was not quite apparent how the `Range<Date>` precondition failure in `queryStatisticsSample` can happen.

The most probable theory is that the device's system wall clock has changed backwards significantly, to the point where the `Date.now()` has moved before (some of the) `VitalAnchor.dates` we stored in the UserDefaults.

* Sanitise the start & end date at the beginning of `queryStatisticsSample`.

* `queryStatisticsSample` now throws a `VitalHealthKitClientError` if the input start & end dates do not make sense.

* `Date.dateAgo(_:_:)` now crashes if an expected `Date` was not produced, instead of silently returning an invalid value.