### PR TITLE
[VIT-3243] Fix the read process being unnecessarily restarted.

### DIFF
--- a/Examples/iOS/Devices Tab/DeviceConnection.swift
+++ b/Examples/iOS/Devices Tab/DeviceConnection.swift
@@ -105,7 +105,7 @@ extension DeviceConnection {
     var canRead: Bool {
       switch self.status {
       case .paired, .readingFailed, .serverSuccess, .serverFailed, .deviceNoData:
-          return scannedDevice != nil
+          return scannedDevice != nil && hasPairedSuccessfully == true
         default:
           return false
       }

--- a/Examples/iOS/Devices Tab/DeviceConnection.swift
+++ b/Examples/iOS/Devices Tab/DeviceConnection.swift
@@ -59,6 +59,7 @@ extension DeviceConnection {
       case creatingConnectedSource = "Creating a Connected Source via API..."
       case searching = "Searching..."
       case pairingFailed = "Pairing failed"
+      case reading = "Reading data..."
       case readingFailed = "Reading failed"
       case sendingToServer = "Sending to server..."
       case deviceNoData = "Device reported no data"
@@ -70,6 +71,7 @@ extension DeviceConnection {
     
     let device: DeviceModel
     var status: Status
+    var hasPairedSuccessfully = false
     var scannedDevice: ScannedDevice?
     var scanSource: ScanSource?
 
@@ -91,9 +93,18 @@ extension DeviceConnection {
       }
     }
 
-    var canPairAndRead: Bool {
+    var canPair: Bool {
       switch self.status {
       case .searching, .pairingFailed, .serverFailed, .serverSuccess, .found:
+          return scannedDevice != nil && hasPairedSuccessfully == false
+        default:
+          return false
+      }
+    }
+
+    var canRead: Bool {
+      switch self.status {
+      case .paired, .readingFailed, .serverSuccess, .serverFailed, .deviceNoData:
           return scannedDevice != nil
         default:
           return false
@@ -122,6 +133,7 @@ extension DeviceConnection {
     case startScanning
     case scannedDevice(ScannedDevice, ScanSource)
 
+    case startReading(ScannedDevice)
     case newReading([Reading])
     case readingSentToServer(Reading)
     case failedSentToServer(String)
@@ -265,6 +277,34 @@ let deviceConnectionReducer = Reducer<DeviceConnection.State, DeviceConnection.A
       state.status = .connectedSourceCreationFailed
       state.alertText = reason
       return .none
+
+    case let .startReading(scannedDevice):
+      state.status = .reading
+
+      let publisher: AnyPublisher<[Reading], Error>
+
+      if scannedDevice.deviceModel.kind == .bloodPressure {
+        let reader = env.deviceManager.bloodPressureReader(for: scannedDevice, queue: env.mainQueue)
+
+        publisher = reader.read(device: scannedDevice)
+          .map { $0.map(Reading.bloodPressure) }
+          .eraseToAnyPublisher()
+
+      } else {
+        let reader = env.deviceManager.glucoseMeter(for: scannedDevice, queue: env.mainQueue)
+
+        publisher = reader.read(device: scannedDevice)
+          .map { $0.map(Reading.glucose) }
+          .eraseToAnyPublisher()
+      }
+
+      return publisher
+        .map(DeviceConnection.Action.newReading)
+        .catch { error in Just(DeviceConnection.Action.readingFailed(error.localizedDescription))}
+        .receive(on: env.mainQueue)
+        .eraseToEffect()
+        .cancellable(id: LongRunningReads())
+
       
     case let .readingFailed(reason):
       state.status = .readingFailed
@@ -279,31 +319,8 @@ let deviceConnectionReducer = Reducer<DeviceConnection.State, DeviceConnection.A
     case let .pairedSuccesfully(scannedDevice):
       state.status = .paired
       state.scannedDevice = scannedDevice
-      
-      let publisher: AnyPublisher<[Reading], Error>
-      
-      if scannedDevice.deviceModel.kind == .bloodPressure {
-        let reader = env.deviceManager.bloodPressureReader(for: scannedDevice, queue: env.mainQueue)
-        
-        publisher = reader.read(device: scannedDevice)
-          .map { $0.map(Reading.bloodPressure) }
-          .eraseToAnyPublisher()
-        
-      } else {
-        let reader = env.deviceManager.glucoseMeter(for: scannedDevice, queue: env.mainQueue)
-        
-        publisher = reader.read(device: scannedDevice)
-          .map { $0.map(Reading.glucose) }
-          .eraseToAnyPublisher()
-      }
-      
-      return publisher
-        .map(DeviceConnection.Action.newReading)
-        .catch { error in Just(DeviceConnection.Action.readingFailed(error.localizedDescription))}
-        .receive(on: env.mainQueue)
-        .eraseToEffect()
-        .cancellable(id: LongRunningReads())
-      
+      state.hasPairedSuccessfully = true
+      return .none
       
     case let .pairDevice(device):
       state.status = .pairing
@@ -360,15 +377,28 @@ extension DeviceConnection {
                 .cornerRadius(5.0)
             }
 
-            Button {
-              if let device = viewStore.scannedDevice {
-                viewStore.send(.pairDevice(device))
+            HStack {
+              Button {
+                if let device = viewStore.scannedDevice {
+                  viewStore.send(.pairDevice(device))
+                }
+              } label: {
+                Text(viewStore.hasPairedSuccessfully ? "Paired" : "Pair")
               }
-            } label: {
-              Text("Pair & Read")
+              .disabled(viewStore.canPair == false)
+              .cornerRadius(8.0)
+
+              Button {
+                if let device = viewStore.scannedDevice {
+                  viewStore.send(.startReading(device))
+                }
+              } label: {
+                Text("Read")
+              }
+              .disabled(viewStore.canRead == false)
+              .cornerRadius(8.0)
             }
-            .buttonStyle(RegularButtonStyle(isDisabled: viewStore.canPairAndRead == false))
-            .cornerRadius(8.0)
+            .buttonStyle(RegularButtonStyle())
             .padding(.vertical, 8)
             .padding(.horizontal, 32)
 

--- a/Sources/VitalDevices/DeviceReading/GATTMeter.swift
+++ b/Sources/VitalDevices/DeviceReading/GATTMeter.swift
@@ -57,6 +57,7 @@ internal class GATTMeter<Sample> {
           .compactMap { $0.flatMap(self.parser) }
           .prefix(untilOutputFrom: racpSuccessOrFailure)
           .collect()
+          .timeout(30.0, scheduler: DispatchQueue.main, customError: { BluetoothError(message: "ReadAllRecords timeout") })
           .handleEvents(
             receiveSubscription: { _ in
               // (2) We then start listening for RACP response indication


### PR DESCRIPTION
The read process sometimes was restarted multiple times.

It seems `_connectAndDiscoverCharacteristics` sometimes redelivers the characteristics consecutively, which then causes flatMapLatest in `read(device:)` to cancel the read process and restart it again.

Since the whole read process is stateful message passing, restarting prematurely without awaiting the Record Access Control Point response and/or without a reasonably long timeout can lead our read process into a stuck state.

Change it so that we take only the first valid value, thus avoiding the restarts.

Doing so requires some more refactoring to avoid cancelling the upstream `connect()` publisher subscription, which will cancel the CBPeripheral connection upon subscription cancellation.

---

Note that this does not address the edge case where an SDK consumer attempts to make >1 `read()` calls concurrently, which is another way to throw the read process into the stuck state.

---

Also:

1. Add a 30second read timeout, so the publisher would not be stuck indefinitely waiting for RACP response.

2. Separate Pair and Read as two separate actions in the Example UI.