### PR TITLE
Wrap all data tasks in beginBackgroundTask

### DIFF
--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -253,22 +253,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       apiKey: apiKey
     )
     
-    let apiClient = APIClient(baseURL: URL(string: environment.host)!) { configuration in
-      configuration.delegate = apiClientDelegate
-      
-      updateAPIClientConfiguration(&configuration)
-      
-      let encoder = JSONEncoder()
-      encoder.dateEncodingStrategy = .iso8601
-      encoder.keyEncodingStrategy = .convertToSnakeCase
-      
-      let decoder = JSONDecoder()
-      decoder.keyDecodingStrategy = .convertFromSnakeCase
-      decoder.dateDecodingStrategy = .iso8601
-      
-      configuration.encoder = encoder
-      configuration.decoder = decoder
-    }
+    let apiClient = makeClient(environment: environment, delegate: apiClientDelegate)
     
     let securePayload = VitalCoreSecurePayload(
       configuration: configuration,

--- a/Sources/VitalCore/Core/Extensions/APIClient+Extensions.swift
+++ b/Sources/VitalCore/Core/Extensions/APIClient+Extensions.swift
@@ -22,5 +22,9 @@ func makeClient(
     
     configuration.encoder = encoder
     configuration.decoder = decoder
+
+    // Needed for UIKit background tasks to work as intended
+    // i.e., Ongoing HTTP connection won't get cut-off when app moves into background
+    configuration.sessionConfiguration.shouldUseExtendedBackgroundIdleMode = true
   }
 }


### PR DESCRIPTION
Wrap data tasks in UIKit background tasks, so that the historical stage has a better chance to run to completion when it initially starts in foreground.