### PR TITLE
VIT-4227: Support Source Type in iOS SDK

### DIFF
--- a/Sources/VitalCore/Core/Client/Data Models/Patches/QuantitySample.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/QuantitySample.swift
@@ -8,11 +8,21 @@ public struct QuantitySample: Equatable, Hashable, Encodable {
   public var endDate: Date
   public var sourceBundle: String?
   public var productType: String?
-  public var type: String?
+  public var type: SourceType?
   public var unit: String
   
   public var metadata: VitalAnyEncodable?
-  
+
+  public var sourceType: SourceType {
+    switch type {
+    case .unknown?, nil:
+      return .infer(sourceBundle: sourceBundle, productType: productType)
+
+    case let type?:
+      return type
+    }
+  }
+
   public init(
     id: String? = nil,
     value: Double,
@@ -20,7 +30,7 @@ public struct QuantitySample: Equatable, Hashable, Encodable {
     endDate: Date,
     sourceBundle: String? = nil,
     productType: String? = nil,
-    type: String? = nil,
+    type: SourceType? = nil,
     unit: String,
     metadata: VitalAnyEncodable? = nil
   ) {
@@ -41,7 +51,7 @@ public struct QuantitySample: Equatable, Hashable, Encodable {
     date: Date,
     sourceBundle: String? = nil,
     productType: String? = nil,
-    type: String? = nil,
+    type: SourceType? = nil,
     unit: String,
     metadata: VitalAnyEncodable? = nil
   ) {

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/SleepPatch.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/SleepPatch.swift
@@ -30,6 +30,10 @@ public struct SleepPatch: Equatable, Encodable {
     public var wristTemperature: [QuantitySample] = []
 
     public var sleepStages: SleepStages = .init()
+
+    public var sourceType: SourceType {
+      return .infer(sourceBundle: sourceBundle, productType: productType)
+    }
     
     public init(
       id: UUID? = nil,

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/SourceType.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/SourceType.swift
@@ -1,0 +1,37 @@
+
+public enum SourceType: String, RawRepresentable, Codable {
+  case unknown
+  case phone
+  case watch
+  case app
+  case multipleSources = "multiple_sources"
+
+  case manualScan = "manual_scan"
+  case cuff
+  case fingerprick
+}
+
+extension SourceType {
+  public static func infer(sourceBundle: String?, productType: String?) -> SourceType {
+    guard let sourceBundle = sourceBundle else {
+      return .unknown
+    }
+
+    if sourceBundle == "com.apple.Health" {
+      return .app
+    }
+
+    if sourceBundle.starts(with: "com.apple.health.") {
+      let productType = (productType ?? "").lowercased()
+      if productType.starts(with: "watch") {
+        return .watch
+      }
+      if productType.starts(with: "phone") {
+        return .phone
+      }
+      return .unknown
+    }
+
+    return .unknown
+  }
+}

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/WorkoutPatch.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/WorkoutPatch.swift
@@ -13,7 +13,11 @@ public struct WorkoutPatch: Equatable, Encodable {
     
     public var heartRate: [QuantitySample] = []
     public var respiratoryRate: [QuantitySample] = []
-    
+
+    public var sourceType: SourceType {
+      return .infer(sourceBundle: sourceBundle, productType: productType)
+    }
+
     public init(
       id: UUID? = nil,
       startDate: Date,

--- a/Sources/VitalDevices/DeviceReading/BloodPressureReader1810.swift
+++ b/Sources/VitalDevices/DeviceReading/BloodPressureReader1810.swift
@@ -63,7 +63,7 @@ private func toBloodPressureReading(data: Data) -> BloodPressureSample? {
       value: SFloat.read(data: pulseBytes),
       startDate: date,
       endDate: date,
-      type: "cuff",
+      type: .cuff,
       unit: "bpm"
     )
   } else {
@@ -75,7 +75,7 @@ private func toBloodPressureReading(data: Data) -> BloodPressureSample? {
     value: SFloat.read(data: systolicBytes),
     startDate: date,
     endDate: date,
-    type: "cuff",
+    type: .cuff,
     unit: units
   )
   let diastolicSample = QuantitySample(
@@ -83,7 +83,7 @@ private func toBloodPressureReading(data: Data) -> BloodPressureSample? {
     value: SFloat.read(data: diastolicBytes),
     startDate: date,
     endDate: date,
-    type: "cuff",
+    type: .cuff,
     unit: units
   )
   

--- a/Sources/VitalDevices/DeviceReading/GlucoseMeter1808.swift
+++ b/Sources/VitalDevices/DeviceReading/GlucoseMeter1808.swift
@@ -96,7 +96,7 @@ private func toGlucoseReading(data: Data) -> QuantitySample? {
     value: value,
     startDate: date,
     endDate: date,
-    type: "fingerprick",
+    type: .fingerprick,
     unit: unit,
     metadata: VitalAnyEncodable(
       ["ble_time_offset": bleTimeOffset]

--- a/Sources/VitalDevices/Extensions/QuantitySample+Glucose.swift
+++ b/Sources/VitalDevices/Extensions/QuantitySample+Glucose.swift
@@ -44,7 +44,7 @@ extension QuantitySample {
       value: glucose.valueUnit,
       startDate: glucose.date,
       endDate: glucose.date,
-      type: "automatic",
+      type: .manualScan,
       unit: "mmol/L",
       metadata: FreestyleLibreGlucoseDigest(glucose: glucose)
         .eraseToAnyEncodable()

--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -346,7 +346,7 @@ struct StatisticsQueryDependencies {
 
           do {
             let vitalStatistics = try values.map { statistics in
-              try VitalStatistics(statistics: statistics, type: type, sources: sources)
+              try VitalStatistics(statistics: statistics, type: type)
             }
 
             continuation.resume(returning: vitalStatistics)

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -1014,34 +1014,7 @@ func queryStatisticsSample(
     date: newEndDate
   )
 
-  let enrichedStatistics = try await enrichWithDates(dependencies: dependency, statistics: statistics)
-
-  return (enrichedStatistics, anchor)
-}
-
-
-func enrichWithDates(
-  dependencies: StatisticsQueryDependencies,
-  statistics: [VitalStatistics]
-) async throws -> [VitalStatistics] {
-  return try await withThrowingTaskGroup(of: VitalStatistics.self) { group in
-    for entry in statistics {
-      group.addTask {
-        let sampleTimeRange = try await dependencies.getFirstAndLastSampleTime(
-          entry.type,
-          entry.startDate ..< entry.endDate
-        )
-
-        if let range = sampleTimeRange {
-          return entry.withSampleDates(first: range.lowerBound, last: range.upperBound)
-        } else {
-          return entry
-        }
-      }
-    }
-
-    return try await group.reduce(into: []) { $0.append($1) }
-  }
+  return (statistics, anchor)
 }
 
 /// We compute one summary per quantity type for the calendar day in the

--- a/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
@@ -149,7 +149,7 @@ extension QuantitySample {
       endDate: sample.endDate,
       sourceBundle: value.sourceRevision.source.bundleIdentifier,
       productType: value.sourceRevision.productType,
-      type: "automatic",
+      type: nil,
       unit: sample.sampleType.toUnitStringRepresentation
     )
   }
@@ -160,7 +160,7 @@ func isValidStatistic(_ statistics: VitalStatistics) -> Bool {
 }
 
 func generateIdForAnchor(_ statistics: VitalStatistics) -> String? {
-  let id = "\(statistics.startDate)-\(statistics.endDate)-\(statistics.type)-\(statistics.value)-\(statistics.sourcesValue)"
+  let id = "\(statistics.startDate)-\(statistics.endDate)-\(statistics.type)-\(statistics.value)"
   return id.sha256()
 }
 
@@ -182,24 +182,17 @@ extension QuantitySample {
     else {
       return nil
     }
-    
-    let metadata = VitalAnyEncodable(
-      [
-        "firstSampleDate": statistics.firstSampleDate,
-        "lastSampleDate": statistics.lastSampleDate
-      ]
-    )
-    
+
     self.init(
       id: idString,
       value: statistics.value,
       startDate: statistics.startDate,
       endDate: statistics.endDate,
-      sourceBundle: statistics.sourcesValue,
-      productType: "n/a",
-      type: "automatic",
+      sourceBundle: nil,
+      productType: nil,
+      type: nil,
       unit: sampleType.toUnitStringRepresentation,
-      metadata: metadata
+      metadata: nil
     )
   }
 }
@@ -448,7 +441,7 @@ extension QuantitySample {
       endDate: categorySample.endDate,
       sourceBundle: categorySample.sourceRevision.source.bundleIdentifier,
       productType: categorySample.sourceRevision.productType,
-      type: "automatic",
+      type: nil,
       unit: "stage"
     )
   }
@@ -468,7 +461,7 @@ extension QuantitySample {
       endDate: sample.endDate,
       sourceBundle: sample.sourceRevision.source.bundleIdentifier,
       productType: sample.sourceRevision.productType,
-      type: "automatic",
+      type: nil,
       unit: "minute"
     )
   }

--- a/Sources/VitalHealthKit/HealthKit/Storage/VitalStatistics.swift
+++ b/Sources/VitalHealthKit/HealthKit/Storage/VitalStatistics.swift
@@ -6,30 +6,19 @@ struct VitalStatistics {
   var startDate: Date
   var endDate: Date
   
-  var sources: [String]
-  
-  var firstSampleDate: Date?
-  var lastSampleDate: Date?
-  
-  var sourcesValue: String {
-    return sources.joined(separator: ",")
-  }
-  
   init(
     value: Double,
     type: HKQuantityType,
     startDate: Date,
-    endDate: Date,
-    sources: [String]
+    endDate: Date
   ) {
     self.value = value
     self.type = type
     self.startDate = startDate
     self.endDate = endDate
-    self.sources = sources
   }
     
-  init(statistics: HKStatistics, type: HKQuantityType, sources: [String]) throws {
+  init(statistics: HKStatistics, type: HKQuantityType) throws {
     let unit = type.toHealthKitUnits
 
     guard
@@ -42,15 +31,7 @@ struct VitalStatistics {
       value: value,
       type: type,
       startDate: statistics.startDate,
-      endDate: statistics.endDate,
-      sources: sources
+      endDate: statistics.endDate
     )
-  }
-
-  func withSampleDates(first: Date, last: Date) -> Self {
-    var copy = self
-    copy.firstSampleDate = first
-    copy.lastSampleDate = last
-    return copy
   }
 }

--- a/Tests/VitalHealthKitTests/VitalHealthKitAnchorTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitAnchorTests.swift
@@ -9,12 +9,12 @@ class VitalHealthKitAnchorTests: XCTestCase {
   func testAnchorsPopulation() {
     let type = HKQuantityType.quantityType(forIdentifier: .stepCount)!
     let input: [VitalStatistics] = [
-      .init(value: 1, type: type, startDate: Date(), endDate: Date(), sources: []),
-      .init(value: 2, type: type, startDate: Date(), endDate: Date(), sources: []),
-      .init(value: 3, type: type, startDate: Date(), endDate: Date(), sources: []),
-      .init(value: 4, type: type, startDate: Date(), endDate: Date(), sources: []),
-      .init(value: 4, type: type, startDate: Date(), endDate: Date(), sources: []),
-      .init(value: 0, type: type, startDate: Date(), endDate: Date(), sources: [])
+      .init(value: 1, type: type, startDate: Date(), endDate: Date()),
+      .init(value: 2, type: type, startDate: Date(), endDate: Date()),
+      .init(value: 3, type: type, startDate: Date(), endDate: Date()),
+      .init(value: 4, type: type, startDate: Date(), endDate: Date()),
+      .init(value: 4, type: type, startDate: Date(), endDate: Date()),
+      .init(value: 0, type: type, startDate: Date(), endDate: Date())
     ]
     
     let values = calculateIdsForAnchorsPopulation(vitalStatistics: input, date: Date())
@@ -37,8 +37,8 @@ class VitalHealthKitAnchorTests: XCTestCase {
     ]
     
     let new: [VitalStatistics] = [
-      .init(value: 5, type: type, startDate: Date(), endDate: Date(), sources: []),
-      .init(value: 0, type: type, startDate: Date(), endDate: Date(), sources: [])
+      .init(value: 5, type: type, startDate: Date(), endDate: Date()),
+      .init(value: 0, type: type, startDate: Date(), endDate: Date())
     ]
     
     let values = calculateIdsForAnchorsAndData(vitalStatistics: new, existingAnchors: existing, key: key, date: Date())
@@ -53,8 +53,8 @@ class VitalHealthKitAnchorTests: XCTestCase {
     ]
     
     let new: [VitalStatistics] = [
-      .init(value: 1, type: type, startDate: Date(), endDate: Date(), sources: []),
-      .init(value: 2, type: type, startDate: Date(), endDate: Date(), sources: [])
+      .init(value: 1, type: type, startDate: Date(), endDate: Date()),
+      .init(value: 2, type: type, startDate: Date(), endDate: Date())
     ]
     
     let values = calculateIdsForAnchorsAndData(vitalStatistics: new, existingAnchors: existing, key: key, date: Date())

--- a/Tests/VitalHealthKitTests/VitalHealthKitReadsTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitReadsTests.swift
@@ -185,12 +185,12 @@ class VitalHealthKitReadsTests: XCTestCase {
     let key = "key"
     var vitalStastics: [[VitalStatistics]] = [
       [
-        .init(value: 10, type: type, startDate: Date(), endDate: Date(), sources: []),
-        .init(value: 20, type: type, startDate: Date(), endDate: Date(), sources: []),
-        .init(value: 30, type: type, startDate: Date(), endDate: Date(), sources: [])
+        .init(value: 10, type: type, startDate: Date(), endDate: Date()),
+        .init(value: 20, type: type, startDate: Date(), endDate: Date()),
+        .init(value: 30, type: type, startDate: Date(), endDate: Date())
       ],
       [
-        .init(value: 5, type: type, startDate: Date(), endDate: Date(), sources: [])
+        .init(value: 5, type: type, startDate: Date(), endDate: Date())
       ]
     ]
     
@@ -273,7 +273,7 @@ class VitalHealthKitReadsTests: XCTestCase {
     let key = "key"
     var vitalStastics: [[VitalStatistics]] = [
       [
-        .init(value: 5, type: type, startDate: Date(), endDate: Date(), sources: [])
+        .init(value: 5, type: type, startDate: Date(), endDate: Date())
       ]
     ]
     


### PR DESCRIPTION
1. Support `Sleep.sourceType`, `Workout.sourceType` and `QuantitySample.sourceType` for local reads to differentiate between iPhone data, Apple Watch data and Apple Health app manual entry.

    * Example app usage: Disable heart rate chart for iPhone sleeps.
    * Example app usage: Show sleep source type

3. Aligned all the `QuantitySample.type` values set by the SDK with the new source type definitions. Most notably, hourly statistics now use `type = multiple_sources`.
