### PR TITLE
VIT-4227: Remove unused logic around hourly statistics

### DIFF
--- a/Tests/VitalHealthKitTests/StatisticalQueryTests.swift
+++ b/Tests/VitalHealthKitTests/StatisticalQueryTests.swift
@@ -29,27 +29,4 @@ class StatisticalQueryTests: XCTestCase {
     }
   }
 
-  func test_getFirstAndLastSampleTime_respects_cooperative_cancellation() async {
-    let dependencies = StatisticsQueryDependencies.live(healthKitStore: HKHealthStore(), vitalStorage: VitalHealthKitStorage(storage: .debug))
-
-    // Run it 100 times to mitigate away any temporary blips that might cause it to pass.
-    for _ in 0 ..< 100 {
-      let task = Task {
-        _ = try await dependencies.getFirstAndLastSampleTime(
-          HKQuantityType.quantityType(forIdentifier: .stepCount)!,
-          Date().addingTimeInterval(-86400) ..< Date()
-        )
-
-        XCTFail("Unexpected return")
-      }
-
-      task.cancel()
-      let result = await task.result
-
-      XCTAssertThrowsError(try result.get()) { error in
-        XCTAssertTrue(error is CancellationError)
-      }
-    }
-  }
-
 }

--- a/Tests/VitalHealthKitTests/VitalHealthKitReadsTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitReadsTests.swift
@@ -221,12 +221,6 @@ class VitalHealthKitReadsTests: XCTestCase {
       let element = vitalStastics.removeFirst()
       return element
     }
-
-    debug.getFirstAndLastSampleTime = { type, _ in
-      XCTAssertEqual(quantityType, type)
-
-      return nil
-    }
     
     debug.isLegacyType = { type in
       XCTAssertEqual(quantityType, type)
@@ -285,11 +279,6 @@ class VitalHealthKitReadsTests: XCTestCase {
 
     var dateRanges: [Range<Date>] = []
 
-    debug.getFirstAndLastSampleTime = { type, _ in
-      XCTAssertEqual(quantityType, type)
-      return nil
-    }
-    
     debug.executeStatisticalQuery = { type, queryInterval, granularity in
       XCTAssertEqual(quantityType, type)
       XCTAssertEqual(granularity, .hourly)


### PR DESCRIPTION
1. Removed source bundle ID query for hourly statistics. 

3. Removed first and last sample time query for hourly statistics.

Neither of these features have been exposed in client facing schema. Most importantly, the planned introduction of activity raw samples would provide a superset of data that cover everything above. So there is no value to productize these.

Since we cut away 1 HKSourceQuery and + N HKStatisticsQuery (1 per VitalStatistics) calls, this would also provide a performance boost. Though it is probably temporary, as the anchored queries for activity raw samples would likely erase a portion of it.