### PR TITLE
VIT-4322: VitalJWTAuth integration with APIClient & VitalClient

### DIFF
--- a/Sources/VitalCore/Core/Client/Data Models/Base Models/LinkCRUD.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Base Models/LinkCRUD.swift
@@ -1,22 +1,22 @@
 import Foundation
 
 public struct CreateConnectionSourceRequest: Encodable {
-  public let userId: UUID
+  public let userId: String
   public let providerId: String?
   
-  public init(userId: UUID, providerId: String? = nil) {
+  public init(userId: String, providerId: String? = nil) {
     self.userId = userId
     self.providerId = providerId
   }
 }
 
 struct CreateLinkRequest: Encodable {
-  let userId: UUID
+  let userId: String
   let provider: String?
   let redirectUrl: String?
   
   init(
-    userId: UUID,
+    userId: String,
     provider: String?,
     redirectUrl: String?
   ) {

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Link.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Link.swift
@@ -42,7 +42,7 @@ public extension VitalClient.Link {
     redirectURL: String?
   ) async throws -> String {
     
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
     
     let path = "/\(configuration.apiVersion)/\(path)/token"
@@ -54,7 +54,7 @@ public extension VitalClient.Link {
   }
   
   func createConnectedSource(
-    _ userId: UUID,
+    _ userId: String,
     provider: Provider.Slug
   ) async throws -> Void {
     
@@ -84,7 +84,7 @@ public extension VitalClient.Link {
   func createConnectedSource(
     for provider: Provider.Slug
   ) async throws -> Void {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     try await createConnectedSource(userId, provider: provider)
   }
   

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Summary.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Summary.swift
@@ -22,7 +22,7 @@ public extension VitalClient.Summary {
     provider: Provider.Slug,
     timeZone: TimeZone
   ) async throws -> Void {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
         
     let taggedPayload = TaggedPayload(
@@ -45,7 +45,7 @@ public extension VitalClient.Summary {
     endDate: Date? = nil,
     provider: Provider.Slug? = nil
   ) async throws -> [SleepSummary] {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
     
     let prefix: String = "/\(configuration.apiVersion)/\(self.resource)/"
@@ -63,7 +63,7 @@ public extension VitalClient.Summary {
     endDate: Date? = nil,
     provider: Provider.Slug? = nil
   ) async throws -> [AnyDecodable] {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
     
     let prefix: String = "/\(configuration.apiVersion)/\(self.resource)/"
@@ -81,7 +81,7 @@ public extension VitalClient.Summary {
     endDate: Date? = nil,
     provider: Provider.Slug? = nil
   ) async throws -> [SleepSummary] {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
     
     let prefix: String = "/\(configuration.apiVersion)/\(self.resource)/"
@@ -99,7 +99,7 @@ public extension VitalClient.Summary {
     endDate: Date? = nil,
     provider: Provider.Slug? = nil
   ) async throws -> [ActivitySummary] {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
     
     let prefix: String = "/\(configuration.apiVersion)/\(self.resource)/"
@@ -117,7 +117,7 @@ public extension VitalClient.Summary {
     endDate: Date? = nil,
     provider: Provider.Slug? = nil
   ) async throws -> [AnyDecodable] {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
     
     let prefix: String = "/\(configuration.apiVersion)/\(self.resource)/"
@@ -135,7 +135,7 @@ public extension VitalClient.Summary {
     endDate: Date? = nil,
     provider: Provider.Slug? = nil
   ) async throws -> [WorkoutSummary] {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
     
     let prefix: String = "/\(configuration.apiVersion)/\(self.resource)/"
@@ -153,7 +153,7 @@ public extension VitalClient.Summary {
     endDate: Date? = nil,
     provider: Provider.Slug? = nil
   ) async throws -> [AnyDecodable] {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
     
     let prefix: String = "/\(configuration.apiVersion)/\(self.resource)/"
@@ -171,7 +171,7 @@ public extension VitalClient.Summary {
     endDate: Date? = nil,
     provider: Provider.Slug? = nil
   ) async throws -> [BodySummary] {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
     
     let prefix: String = "/\(configuration.apiVersion)/\(self.resource)/"
@@ -189,7 +189,7 @@ public extension VitalClient.Summary {
     endDate: Date? = nil,
     provider: Provider.Slug? = nil
   ) async throws -> [AnyDecodable] {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
     
     let prefix: String = "/\(configuration.apiVersion)/\(self.resource)/"

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
@@ -36,7 +36,7 @@ public extension VitalClient.TimeSeries {
     provider: Provider.Slug,
     timeZone: TimeZone
   ) async throws -> Void {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
 
     let taggedPayload = TaggedPayload(
@@ -46,7 +46,7 @@ public extension VitalClient.TimeSeries {
       data: VitalAnyEncodable(timeSeriesData.payload)
     )
     
-    let fullPath: String = await makePath(for: timeSeriesData.name, userId: userId.uuidString)
+    let fullPath: String = await makePath(for: timeSeriesData.name, userId: userId)
     let request: Request<Void> = .init(path: fullPath, method: .post, body: taggedPayload)
     
     configuration.logger?.info("Posting TimeSeries data for: \(timeSeriesData.name, privacy: .public)")
@@ -60,13 +60,13 @@ public extension VitalClient.TimeSeries {
     provider: Provider.Slug? = nil
   ) async throws -> [TimeSeriesDataPoint] {
     
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
 
     let query = makeBaseQuery(startDate: startDate, endDate: endDate, provider: provider)
     let path = resource.toPath
     
-    let fullPath = await makePath(for: path, userId: userId.uuidString)
+    let fullPath = await makePath(for: path, userId: userId)
     
     let request: Request<[TimeSeriesDataPoint]> = .init(path: fullPath, method: .get, query: query)
     
@@ -80,10 +80,10 @@ public extension VitalClient.TimeSeries {
     provider: Provider.Slug? = nil
   ) async throws -> [BloodPressureDataPoint] {
     
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
 
-    let path = await makePath(for: "blood_pressure", userId: userId.uuidString)
+    let path = await makePath(for: "blood_pressure", userId: userId)
     let query = makeBaseQuery(startDate: startDate, endDate: endDate, provider: provider)
     
     let request: Request<[BloodPressureDataPoint]> = .init(path: path, method: .get, query: query)

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+User.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+User.swift
@@ -16,7 +16,7 @@ public extension VitalClient {
 public extension VitalClient.User {
 
   func userConnectedSources() async throws -> [Provider] {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
 
     let path = "/\(configuration.apiVersion)/\(path)/providers/\(userId)"
@@ -61,7 +61,7 @@ public extension VitalClient.User {
   }
   
   func deregisterProvider(provider: Provider.Slug) async throws -> Void {
-    let userId = await self.client.userId.get()
+    let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
     
     let path = "/\(configuration.apiVersion)/\(path)/\(userId)/\(provider.rawValue)"

--- a/Sources/VitalCore/Core/Storage/VitalCoreStorage.swift
+++ b/Sources/VitalCore/Core/Storage/VitalCoreStorage.swift
@@ -2,8 +2,8 @@ import SwiftUI
 import HealthKit
 
 public struct VitalBackStorage {
-  public var isConnectedSourceStored: (UUID, Provider.Slug) -> Bool
-  public var storeConnectedSource: (UUID, Provider.Slug) -> Void
+  public var isConnectedSourceStored: (String, Provider.Slug) -> Bool
+  public var storeConnectedSource: (String, Provider.Slug) -> Void
   
   public var flagResource: (VitalResource) -> Void
   public var isResourceFlagged: (VitalResource) -> Bool
@@ -25,8 +25,8 @@ public struct VitalBackStorage {
     let defaultValue: [String: String] = [:]
     userDefaults.register(defaults: defaultValue)
     
-    let generateKey: (UUID, Provider.Slug) -> String = { userId, provider in
-      return "\(userId.uuidString)-\(provider.rawValue)"
+    let generateKey: (String, Provider.Slug) -> String = { userId, provider in
+      return "\(userId)-\(provider.rawValue)"
     }
     
     return .init { userId, provider in
@@ -65,8 +65,8 @@ public struct VitalBackStorage {
 
     var dateStorage: [String: Double] = [:]
 
-    let generateKey: (UUID, Provider.Slug) -> String = { userId, provider in
-      return "\(userId.uuidString)-\(provider.rawValue)"
+    let generateKey: (String, Provider.Slug) -> String = { userId, provider in
+      return "\(userId)-\(provider.rawValue)"
     }
     
     return .init { userId, provider in
@@ -104,11 +104,11 @@ class VitalCoreStorage {
     self.storage = storage
   }
   
-  func storeConnectedSource(for userId: UUID, with provider: Provider.Slug) {
+  func storeConnectedSource(for userId: String, with provider: Provider.Slug) {
     storage.storeConnectedSource(userId, provider)
   }
   
-  func isConnectedSourceStored(for userId: UUID, with provider: Provider.Slug) -> Bool {
+  func isConnectedSourceStored(for userId: String, with provider: Provider.Slug) -> Bool {
     return storage.isConnectedSourceStored(userId, provider)
   }
   

--- a/Sources/VitalCore/JWT/VitalJWTAuth.swift
+++ b/Sources/VitalCore/JWT/VitalJWTAuth.swift
@@ -24,8 +24,50 @@ internal actor VitalJWTAuth {
     self.session = URLSession(configuration: .ephemeral)
   }
 
-  func signIn() async throws {
-    // TODO: Perform the token exchange API call
+  func signIn(_ token: String) async throws {
+    guard try getRecord() == nil else {
+      // Already signed-in
+      return
+    }
+
+    let signInToken = try VitalSignInToken.decode(from: token)
+    let claims = try signInToken.unverifiedClaims()
+
+    var components = URLComponents(string: "https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken")!
+    components.queryItems = [URLQueryItem(name: "key", value: signInToken.publicKey)]
+    var request = URLRequest(url: components.url!)
+
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONEncoder().encode(
+      FirebaseTokenExchangeRequest(token: signInToken.userToken, tenantId: claims.teamId)
+    )
+
+    let (data, response) = try await session.data(for: request)
+    let httpResponse = response as! HTTPURLResponse
+
+    switch httpResponse.statusCode {
+    case 200 ... 299:
+      let decoder = JSONDecoder()
+      let exchangeResponse = try decoder.decode(FirebaseTokenExchangeResponse.self, from: data)
+
+      let record = VitalJWTAuthRecord(
+        userId: claims.userId,
+        teamId: claims.teamId,
+        publicApiKey: signInToken.publicKey,
+        accessToken: exchangeResponse.idToken,
+        refreshToken: exchangeResponse.refreshToken,
+        expiry: Date().addingTimeInterval(Double(exchangeResponse.expiresIn) ?? 3600)
+     )
+
+      try setRecord(record)
+
+    case 401:
+      throw VitalJWTAuthError.reauthenticationNeeded
+
+    default:
+      throw VitalJWTAuthError.tokenRefreshFailure
+    }
   }
 
   func signOut() async throws {
@@ -148,7 +190,7 @@ private struct VitalJWTAuthRecord: Codable {
   }
 }
 
-private struct FirebaseTokenRefreshResponse: Codable {
+private struct FirebaseTokenRefreshResponse: Decodable {
   let expiresIn: String
   let refreshToken: String
   let idToken: String
@@ -157,6 +199,84 @@ private struct FirebaseTokenRefreshResponse: Codable {
     case expiresIn = "expires_in"
     case refreshToken = "refresh_token"
     case idToken = "id_token"
+  }
+}
+
+private struct FirebaseTokenExchangeRequest: Encodable {
+  let returnSecureToken = true
+  let token: String
+  let tenantId: String
+}
+
+private struct FirebaseTokenExchangeResponse: Decodable {
+  let expiresIn: String
+  let refreshToken: String
+  let idToken: String
+}
+
+internal struct VitalSignInToken: Hashable, Decodable {
+  let publicKey: String
+  let userToken: String
+
+  init(publicKey: String, userToken: String) {
+    self.publicKey = publicKey
+    self.userToken = userToken
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case publicKey = "public_key"
+    case userToken = "user_token"
+  }
+
+  static func decode(from token: String) throws -> VitalSignInToken {
+    guard let unwrappedData = Data(base64Encoded: token) else {
+      throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "token is not valid base64 blob"))
+    }
+    return try JSONDecoder().decode(VitalSignInToken.self, from: unwrappedData)
+  }
+
+  func unverifiedClaims() throws -> VitalSignInTokenClaims {
+    let components = userToken.split(separator: ".")
+    guard components.count == 3 else {
+      throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "malformed JWT [0]"))
+    }
+
+    guard
+      let rawHeader = Data(base64Encoded: padBase64(components[0])),
+      let rawClaims = Data(base64Encoded: padBase64(components[1]))
+    else {
+      throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "malformed JWT [1]"))
+    }
+
+    let decoder = JSONDecoder()
+    let headers = try decoder.decode([String: String].self, from: rawHeader)
+
+    guard headers["alg"] == "RS256" && headers["typ"] == "JWT" else {
+      throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "malformed JWT [2]"))
+    }
+
+    return try decoder.decode(VitalSignInTokenClaims.self, from: rawClaims)
+  }
+}
+
+private func padBase64(_ string: any StringProtocol) -> String {
+  let pad = string.count % 4
+  print(pad)
+  print(string)
+  if pad == 0 {
+    return String(string)
+  } else {
+    return string + String(repeating: "=", count: 4 - pad)
+  }
+}
+
+internal struct VitalSignInTokenClaims: Decodable {
+  let userId: String
+  let teamId: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId = "uid"
+    case teamId = "tenant_id"
   }
 }
 

--- a/Tests/VitalCoreTests/VitalClientTests.swift
+++ b/Tests/VitalCoreTests/VitalClientTests.swift
@@ -4,7 +4,7 @@ import Mocker
 @testable import VitalCore
 
 let environment = Environment.sandbox(.us)
-let userId = UUID()
+let userId = UUID().uuidString
 let apiKey = UUID().uuidString
 let apiVersion = "2.0"
 let provider = Provider.Slug.strava
@@ -39,10 +39,10 @@ class VitalClientTests: XCTestCase {
       updateAPIClientConfiguration: makeMockApiClient(configuration:)
     )
     
-    await VitalClient.setUserId(userId)
+    await VitalClient.setUserId(UUID(uuidString: userId)!)
     
     let securePayload: VitalCoreSecurePayload? = try? secureStorage.get(key: core_secureStorageKey)
-    let storedUserId: UUID? = try? secureStorage.get(key: user_secureStorageKey)
+    let storedUserId: String? = try? secureStorage.get(key: user_secureStorageKey)
     
     XCTAssertEqual(securePayload?.configuration.logsEnable, false)
     XCTAssertEqual(securePayload?.apiVersion, apiVersion)
@@ -55,12 +55,9 @@ class VitalClientTests: XCTestCase {
     )
     
     await VitalClient.shared.cleanUp()
-    
-    let inMemoryStoredUser = VitalClient.shared.userId.isNil()
-    let inMemoryStoredConfiguration = VitalClient.shared.configuration.isNil()
-    
-    XCTAssertTrue(inMemoryStoredUser)
-    XCTAssertTrue(inMemoryStoredConfiguration)
+
+    XCTAssertTrue(VitalClient.shared.apiKeyModeUserId.isNil())
+    XCTAssertTrue(VitalClient.shared.configuration.isNil())
     
     let nilSecurePayload: VitalCoreSecurePayload? = try? secureStorage.get(key: core_secureStorageKey)
     let nilStoredUserId: UUID? = try? secureStorage.get(key: user_secureStorageKey)
@@ -81,7 +78,7 @@ class VitalClientTests: XCTestCase {
     }
 
     let nilConfiguration = VitalClient.shared.configuration.isNil()
-    let nilUserId = VitalClient.shared.userId.isNil()
+    let nilUserId = VitalClient.shared.apiKeyModeUserId.isNil()
 
     XCTAssertTrue(nilUserId)
     XCTAssertTrue(nilConfiguration)
@@ -107,7 +104,7 @@ class VitalClientTests: XCTestCase {
     }
 
     let nonNilConfiguration = VitalClient.shared.configuration.isNil()
-    let nonNilUserId = VitalClient.shared.userId.isNil()
+    let nonNilUserId = VitalClient.shared.apiKeyModeUserId.isNil()
 
     XCTAssertFalse(nonNilUserId)
     XCTAssertFalse(nonNilConfiguration)
@@ -121,7 +118,7 @@ class VitalClientTests: XCTestCase {
     }
 
     XCTAssertNil(VitalClient.shared.configuration.value)
-    XCTAssertNil(VitalClient.shared.userId.value)
+    XCTAssertNil(VitalClient.shared.apiKeyModeUserId.value)
 
     // TEST: Set userId only. `automaticConfiguration` should skip setting it,
     // since a configuration is not present.
@@ -138,7 +135,7 @@ class VitalClientTests: XCTestCase {
     }
 
     XCTAssertNil(VitalClient.shared.configuration.value)
-    XCTAssertNil(VitalClient.shared.userId.value)
+    XCTAssertNil(VitalClient.shared.apiKeyModeUserId.value)
   }
   
   func testStorageIsCleanedUpOnUserIdChange() async {
@@ -154,7 +151,7 @@ class VitalClientTests: XCTestCase {
       updateAPIClientConfiguration: makeMockApiClient(configuration:)
     )
     
-    await VitalClient.setUserId(userId)
+    await VitalClient.setUserId(UUID(uuidString: userId)!)
     
     await VitalClient.setUserId(UUID())
     
@@ -175,7 +172,7 @@ class VitalClientTests: XCTestCase {
       updateAPIClientConfiguration: makeMockApiClient(configuration:)
     )
     
-    await VitalClient.setUserId(userId)
+    await VitalClient.setUserId(UUID(uuidString: userId)!)
     
     let isConnected = try! await VitalClient.shared.isUserConnected(to: provider)
     XCTAssertTrue(isConnected)

--- a/Tests/VitalCoreTests/VitalJWTAuthSerializationTests.swift
+++ b/Tests/VitalCoreTests/VitalJWTAuthSerializationTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+@testable import VitalCore
+
+class VitalJWTAuthSerializationTests: XCTestCase {
+  func test_signInToken_getUnverifiedClaims() throws {
+    let fakeToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiJjMzZkNGRmNS1lMzczLTQyNWQtYWFlNy04YjA5MWIwMDNkZGQiLCJ0ZW5hbnRfaWQiOiI3ZWFlNTc0ZC04Yjc4LTRhZTAtYWM4ZC1lY2JlNTY3YjU1NTUifQ.ddHeC7lrK5ripQMjhIdMsqw-DN98UDroaKNabjX4HvkroHb4GrJSVNzlvJucmfnxWZdBKgIPrZa4ObqwfOPx5Hm59fMk9DCMlDr8F3A7jNcnxE0tP5zcR218S8eBXyMlaMQ8uGHCcoJSMWQTDOnE9eVhHIZ4dJ1dV94svpLVQkXSJEz9p7Wob1i1AkcsZnelO0G9EXe9-bYTUAeCtCQwzGDrabhSZAtYo9RSMTXPUlBTq-n6a6LoE1ZjvicJa7XdmEfwrRYiOhWyKP4fWFW1qfwpU7v7isAc0v2WGMKlh8LFM0I9F5prhTbYNRcGFfYxBCBFCj71KDLWNo6j8gbsbA"
+
+    let token = VitalSignInToken(publicKey: "", userToken: fakeToken)
+    let claims = try token.unverifiedClaims()
+
+    XCTAssertEqual(claims.userId, "c36d4df5-e373-425d-aae7-8b091b003ddd")
+    XCTAssertEqual(claims.teamId, "7eae574d-8b78-4ae0-ac8d-ecbe567b5555")
+  }
+}


### PR DESCRIPTION
Integrate VitalJWTAuth into APIClient & VitalClient as an opt-in mode.

The SDK still defaults to the (legacy) API Key mode.


