### PR TITLE
VIT-4345: Revamp iOS demo app settings screen

### DIFF
--- a/Examples/iOS/Devices Tab/DeviceConnection.swift
+++ b/Examples/iOS/Devices Tab/DeviceConnection.swift
@@ -170,7 +170,7 @@ let deviceConnectionReducer = Reducer<DeviceConnection.State, DeviceConnection.A
       let brand = state.device.brand
 
       return Effect<DeviceConnection.Action, Never>.task {
-        guard await VitalClient.isConfigured else {
+        guard VitalClient.status.contains([.configured, .signedIn]) else {
           return DeviceConnection.Action.connectedSourceCreationFailure("Vital SDK has not been configured.")
         }
 

--- a/Examples/iOS/Root.swift
+++ b/Examples/iOS/Root.swift
@@ -88,14 +88,6 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
 
   Reducer { state, action, environment in
     switch action {
-      
-      case .settings(.setup), .settings(.save):
-//        if VitalClient.isSetup {
-//          return Effect<AppAction, Never>(value: AppAction.linkCreation(.startTimer))
-//        }
-//
-        return .none
-        
       case let .callback(url):
         return Effect<AppAction, Never>(value: AppAction.linkCreation(.callback(url)))
         

--- a/Sources/VitalCore/JWT/VitalJWTAuth.swift
+++ b/Sources/VitalCore/JWT/VitalJWTAuth.swift
@@ -17,6 +17,11 @@ internal actor VitalJWTAuth {
   internal static let live = VitalJWTAuth()
   private static let keychainKey = "vital_jwt_auth"
 
+  nonisolated var currentUserId: String? {
+    let record: VitalJWTAuthRecord? = try? storage.get(key: Self.keychainKey)
+    return record?.userId
+  }
+
   private let storage: VitalSecureStorage
   private let session: URLSession
 


### PR DESCRIPTION
1. Improve information density

2. Separate demo configuration and SDK state.

3. Support switching between API Key mode and Sign-In Token Demo mode (emulating the JWT flow using the API Key for testing purpose).

