### PR TITLE
VIT-4423: Add blood oxygen as an independent resource

### DIFF
--- a/Sources/VitalCore/Core/Client/Data Models/Base Models/ResourceData.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Base Models/ResourceData.swift
@@ -64,6 +64,7 @@ public enum NutritionData: Equatable, Encodable {
 
 public enum TimeSeriesData: Equatable, Encodable {
   case glucose([QuantitySample])
+  case bloodOxygen([QuantitySample])
   case bloodPressure([BloodPressureSample])
   case heartRate([QuantitySample])
   case heartRateVariability([QuantitySample])
@@ -75,6 +76,8 @@ public enum TimeSeriesData: Equatable, Encodable {
     switch self {
       case let .glucose(dataPoints):
         return dataPoints
+      case let .bloodOxygen(samples):
+        return samples
       case let .bloodPressure(dataPoints):
         return dataPoints
       case let .heartRate(dataPoints):
@@ -91,6 +94,8 @@ public enum TimeSeriesData: Equatable, Encodable {
   public var shouldSkipPost: Bool {
     switch self {
       case let .glucose(samples):
+        return samples.isEmpty
+      case let .bloodOxygen(samples):
         return samples.isEmpty
       case let .bloodPressure(samples):
         return samples.isEmpty
@@ -109,6 +114,8 @@ public enum TimeSeriesData: Equatable, Encodable {
     switch self {
       case .bloodPressure:
         return "blood_pressure"
+      case .bloodOxygen:
+        return "blood_oxygen"
       case .glucose:
         return "glucose"
       case .heartRate:

--- a/Sources/VitalCore/Core/Client/Data Models/Base Models/VitalResource.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Base Models/VitalResource.swift
@@ -2,6 +2,7 @@ public enum VitalResource: Equatable, Hashable, Codable {
   public enum Vitals: Equatable, Hashable, Codable {
     case glucose
     case bloodPressure
+    case bloodOxygen
     case hearthRate
     case heartRateVariability
     case mindfulSession
@@ -12,6 +13,8 @@ public enum VitalResource: Equatable, Hashable, Codable {
           return "glucose"
         case .bloodPressure:
           return "bloodPressure"
+        case .bloodOxygen:
+          return "bloodOxygen"
         case .hearthRate:
           return "hearthRate"
         case .heartRateVariability:
@@ -87,6 +90,7 @@ public enum VitalResource: Equatable, Hashable, Codable {
     
     .vitals(.glucose),
     .vitals(.bloodPressure),
+    .vitals(.bloodOxygen),
     .vitals(.hearthRate),
     .vitals(.heartRateVariability),
     .vitals(.mindfulSession),

--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -64,6 +64,9 @@ extension VitalHealthKitStore {
         
       case HKSampleType.quantityType(forIdentifier: .bloodGlucose)!:
         return .vitals(.glucose)
+
+      case HKSampleType.quantityType(forIdentifier: .oxygenSaturation)!:
+        return .vitals(.bloodOxygen)
         
       case
         HKSampleType.quantityType(forIdentifier: .bloodPressureSystolic)!,

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -208,7 +208,18 @@ func read(
       )
       
       return (.summary(.workout(payload.workoutPatch)), payload.anchors)
-      
+
+    case .vitals(.bloodOxygen):
+      let payload = try await handleTimeSeries(
+        type: .quantityType(forIdentifier: .oxygenSaturation)!,
+        healthKitStore: healthKitStore,
+        vitalStorage: vitalStorage,
+        startDate: startDate,
+        endDate: endDate
+      )
+
+      return (.timeSeries(.bloodOxygen(payload.samples)), payload.anchors)
+
     case .vitals(.glucose):
       let payload = try await handleTimeSeries(
         type: .quantityType(forIdentifier: .bloodGlucose)!,

--- a/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
@@ -35,6 +35,10 @@ func toHealthKitTypes(resource: VitalResource) -> Set<HKObjectType> {
       return [
         HKSampleType.quantityType(forIdentifier: .bodyFatPercentage)!,
       ]
+    case .vitals(.bloodOxygen):
+      return [
+        HKSampleType.quantityType(forIdentifier: .oxygenSaturation)!,
+      ]
       
     case .profile:
       return [
@@ -156,6 +160,12 @@ func observedSampleTypes() -> [[HKSampleType]] {
     [
       HKSampleType.quantityType(forIdentifier: .bloodGlucose)!
     ],
+
+    /// Vitals Blood Oxygen
+    [
+      HKSampleType.quantityType(forIdentifier: .oxygenSaturation)!
+    ],
+
 
     /// Mindfuless Minutes
     [

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -680,7 +680,7 @@ func transform(data: ProcessedResourceData, calendar: Calendar) -> ProcessedReso
       let newSamples = average(samples, calendar: calendar)
       return .timeSeries(.heartRate(newSamples))
       
-    case .timeSeries(.bloodPressure), .timeSeries(.glucose), .timeSeries(.nutrition), .timeSeries(.mindfulSession), .timeSeries(.heartRateVariability):
+    case .timeSeries:
       return data
   }
 }


### PR DESCRIPTION
Blood Oxygen should be synced as an individual resource.

We added it as embedded samples of ManualSleepCreation, but in practice there is no observable correlation or causation between an Apple Watch sleep session and an Apple Watch writing blood oxygen sample. The later appears to be running on its own terms.


