### PR TITLE
Further improve historical stage resiliency against app moving into background

### DIFF
--- a/Sources/VitalCore/Core/Client/ProtectedBox+BackgroundTask.swift
+++ b/Sources/VitalCore/Core/Client/ProtectedBox+BackgroundTask.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+extension ProtectedBox where T == UIBackgroundTaskIdentifier {
+  public func start(_ name: String, expiration: @escaping () -> Void) {
+    let taskId = UIApplication.shared.beginBackgroundTask(withName: name) { [weak self] in
+      expiration()
+      self?.endIfNeeded()
+    }
+    set(value: taskId)
+  }
+
+  public func endIfNeeded() {
+    if let taskId = clean(), taskId != .invalid {
+      UIApplication.shared.endBackgroundTask(taskId)
+    }
+  }
+}

--- a/Sources/VitalHealthKit/HealthKit/Models/BackgroundDeliveryPayload.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/BackgroundDeliveryPayload.swift
@@ -2,5 +2,10 @@ import HealthKit
 
 struct BackgroundDeliveryPayload {
   let sampleTypes: Set<HKSampleType>
-  let completion: () -> Void
+  let completion: (Completion) -> Void
+
+  enum Completion {
+    case cancelled
+    case completed
+  }
 }

--- a/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
+++ b/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
@@ -10,6 +10,8 @@ class VitalHealthKitStorage {
 
   private let flag = "vital_anchor_"
 
+  private let initialSyncDone = "initial_sync_done"
+
   private let storage: VitalBackStorage
   
   init(storage: VitalBackStorage) {
@@ -22,6 +24,14 @@ class VitalHealthKitStorage {
   
   func readFlag(for resource: VitalResource) -> Bool {
     return storage.isResourceFlagged(resource)
+  }
+
+  func setCompletedInitialSync() {
+    storage.store(Data([0x01]), initialSyncDone)
+  }
+
+  func hasCompletedInitalSync() -> Bool {
+    return storage.read(initialSyncDone) == Data([0x01])
   }
   
   func isLegacyType(for key: String) -> Bool {


### PR DESCRIPTION
1. endBackgroundTask needs to be called consistently to balance out the beginBackgroundTask call.

2. We now proactively perform an initial sync on newly requested resources, all of which would be wrapped by a single UIKit background task.


