### PR TITLE
[VIT-5323] Take lower case value in consideration when filtering sleeps

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -1349,10 +1349,9 @@ private func filter(samples: [HKSample], by dataSources: [DataSource]) -> [HKSam
   return samples.filter { sample in
     let identifier = sample.sourceRevision.source.bundleIdentifier
 
-    guard 
+    if
       let wasUserEntered = sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool,
-      wasUserEntered == false
-    else {
+      wasUserEntered == true {
       /// If it's manually entered, allow the sample
       return true
     }

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -1345,10 +1345,10 @@ private func filterForWatch(samples: [HKSample]) -> [HKSample] {
 
 private func filter(samples: [HKSample], by dataSources: [DataSource]) -> [HKSample] {
   return samples.filter { sample in
-    let identifier = sample.sourceRevision.source.bundleIdentifier
+    let identifier = sample.sourceRevision.source.bundleIdentifier.lowercased()
     
     for dataSource in dataSources {
-      if identifier.contains(dataSource.rawValue) {
+      if identifier.contains(dataSource.rawValue.lowercased()) {
         return true
       }
     }


### PR DESCRIPTION
This will allow any sleep generated by a user to be passed in (or by the iPhone itself). I am confident that before this PR, the code was filtering out sleeps generated by the iPhone as well (not just the ones generated manually by the user).