### PR TITLE
Formalize VitalClient.sdkVersion

### DIFF
--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -2,8 +2,6 @@ import Foundation
 import os.log
 import Combine
 
-let sdk_version = "0.10.8"
-
 struct Credentials: Equatable, Hashable {
   let apiKey: String
   let environment: Environment
@@ -165,6 +163,7 @@ let core_secureStorageKey: String = "core_secureStorageKey"
 let user_secureStorageKey: String = "user_secureStorageKey"
 
 @objc public class VitalClient: NSObject {
+  public static let sdkVersion = "0.10.8"
   
   private let secureStorage: VitalSecureStorage
   let configuration: ProtectedBox<VitalCoreConfiguration>

--- a/Sources/VitalCore/Core/Client/VitalClientDelegates.swift
+++ b/Sources/VitalCore/Core/Client/VitalClientDelegates.swift
@@ -29,7 +29,7 @@ class VitalClientDelegate: APIClientDelegate {
       request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "authorization")
     }
 
-    request.setValue(sdk_version, forHTTPHeaderField: "x-vital-ios-sdk-version")
+    request.setValue(VitalClient.sdkVersion, forHTTPHeaderField: "x-vital-ios-sdk-version")
 
     let components = Set(request.url?.pathComponents ?? []).intersection(Set(["timeseries", "summary"]))
     
@@ -71,7 +71,7 @@ class VitalClientDelegate: APIClientDelegate {
 
 class VitalBaseClientDelegate: APIClientDelegate {
   func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws {
-    request.setValue(sdk_version, forHTTPHeaderField: "x-vital-ios-sdk-version")
+    request.setValue(VitalClient.sdkVersion, forHTTPHeaderField: "x-vital-ios-sdk-version")
   }
   
   func client(_ client: APIClient, validateResponse response: HTTPURLResponse, data: Data, task: URLSessionTask) throws {


### PR DESCRIPTION
Expose SDK version so that Flutter and RN do not need to maintain their own copies.

