### PR TITLE
VIT-5618: Fix cleanUp() not clearing sign-in state in some edge cases

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/vital-ios-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/vital-ios-Package.xcscheme
@@ -90,6 +90,16 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "VitalDevicesTests"
+               BuildableName = "VitalDevicesTests"
+               BlueprintName = "VitalDevicesTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Tests/VitalCoreTests/VitalClientTests.swift
+++ b/Tests/VitalCoreTests/VitalClientTests.swift
@@ -10,8 +10,9 @@ let apiVersion = "2.0"
 let provider = Provider.Slug.strava
 
 class VitalClientTests: XCTestCase {
+  let storage = VitalCoreStorage(storage: .debug)
   let secureStorage = VitalSecureStorage(keychain: .debug)
-  lazy var client = VitalClient(secureStorage: secureStorage)
+  lazy var client = VitalClient(secureStorage: secureStorage, storage: storage)
 
   override func setUp() async throws {
     await VitalClient.shared.cleanUp()
@@ -23,7 +24,6 @@ class VitalClientTests: XCTestCase {
   }
   
   func testStorageAndCleanUp() async throws {
-    let storage = VitalCoreStorage(storage: .debug)
     storage.storeConnectedSource(for: userId, with: provider)
 
     /// Ideally we would call `VitalClient.configure(...)`
@@ -33,7 +33,6 @@ class VitalClientTests: XCTestCase {
     client.setConfiguration(
       strategy: .apiKey(apiKey, environment),
       configuration: .init(logsEnable: false),
-      storage: storage,
       apiVersion: apiVersion,
       updateAPIClientConfiguration: makeMockApiClient(configuration:)
     )
@@ -188,13 +187,11 @@ class VitalClientTests: XCTestCase {
   }
   
   func testStorageIsCleanedUpOnUserIdChange() async {
-    let storage = VitalCoreStorage(storage: .debug)
     storage.storeConnectedSource(for: userId, with: provider)
     
     client.setConfiguration(
       strategy: .apiKey(apiKey, environment),
       configuration: .init(logsEnable: false),
-      storage: storage,
       apiVersion: apiVersion,
       updateAPIClientConfiguration: makeMockApiClient(configuration:)
     )
@@ -208,13 +205,11 @@ class VitalClientTests: XCTestCase {
   }
   
   func testProviderIsStored() async {
-    let storage = VitalCoreStorage(storage: .debug)
     storage.storeConnectedSource(for: userId, with: provider)
 
     client.setConfiguration(
       strategy: .apiKey(apiKey, environment),
       configuration: .init(logsEnable: false),
-      storage: storage,
       apiVersion: apiVersion,
       updateAPIClientConfiguration: makeMockApiClient(configuration:)
     )


### PR DESCRIPTION
The availability of VitalCoreStorage is no longer contingent on the SDK having been configured.

cleanUp() now always attempts to clear VitalCoreStorage and VitalJWTAuth, irrespective of the SDK configuration state.

