### PR TITLE
[VIT-5634] Clean up rogue imports

### DIFF
--- a/Sources/VitalCore/Core/Storage/VitalCoreStorage.swift
+++ b/Sources/VitalCore/Core/Storage/VitalCoreStorage.swift
@@ -1,4 +1,4 @@
-import SwiftUI
+import Foundation
 
 public struct VitalBackStorage {
   public var isConnectedSourceStored: (String, Provider.Slug) -> Bool

--- a/Sources/VitalCore/Core/Storage/VitalCoreStorage.swift
+++ b/Sources/VitalCore/Core/Storage/VitalCoreStorage.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import HealthKit
 
 public struct VitalBackStorage {
   public var isConnectedSourceStored: (String, Provider.Slug) -> Bool

--- a/Sources/VitalCore/Core/Storage/VitalSecureStorage.swift
+++ b/Sources/VitalCore/Core/Storage/VitalSecureStorage.swift
@@ -1,4 +1,4 @@
-import SwiftUI
+import Foundation
 
 public struct Keychain {
   var set: (Data, String) -> Void


### PR DESCRIPTION
We were using `HealthKit` and `SwiftUI` in places we shouldn't. 