### PR TITLE
CS1-119: iOS: Ability to Pause HealthKit Synchronization

### DIFF
--- a/Examples/iOS/HealthKit Tab/HealthKitExample.swift
+++ b/Examples/iOS/HealthKit Tab/HealthKitExample.swift
@@ -5,6 +5,7 @@ import VitalCore
 
 struct HealthKitExample: View {
   @State var permissions: [VitalResource: Bool] = [:]
+  @State var pauseSync = VitalHealthKitClient.shared.pauseSynchronization
 
   var body: some View {
     NavigationView {
@@ -36,6 +37,8 @@ struct HealthKitExample: View {
           }
           .buttonStyle(PlainButtonStyle())
         }
+
+        Toggle(isOn: $pauseSync) { Text("Pause Synchronization") }
         
         Button("Add water 1L") {
           Task {
@@ -65,6 +68,9 @@ struct HealthKitExample: View {
             ($0, VitalHealthKitClient.shared.hasAskedForPermission(resource: $0))
           }
         )
+      }
+      .onChange(of: self.pauseSync) { pauseSync in
+        VitalHealthKitClient.shared.pauseSynchronization = pauseSync
       }
     }
   }

--- a/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
+++ b/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
@@ -11,6 +11,7 @@ class VitalHealthKitStorage {
   private let flag = "vital_anchor_"
 
   private let initialSyncDone = "initial_sync_done"
+  private let pauseSync = "pause_sync"
 
   private let storage: VitalBackStorage
   
@@ -42,6 +43,15 @@ class VitalHealthKitStorage {
   func isFirstTimeSycingType(for key: String) -> Bool {
     let anchor = self.read(key: key)
     return anchor?.vitalAnchors == nil && anchor?.date == nil && anchor?.anchor == nil
+  }
+
+  func shouldPauseSynchronization() -> Bool {
+    // Default is nil; so this evaluate to false
+    return storage.read(pauseSync) == Data([0x01])
+  }
+
+  func setPauseSynchronization(_ newValue: Bool) {
+    storage.store(Data([newValue ? 0x01 : 0x0]), pauseSync)
   }
   
   func store(entity: StoredAnchor) {


### PR DESCRIPTION
Introduce `VitalHealthKitClient.shared.pauseSynchronization` which can pause synchronisation without having to reset the SDK via `cleanUp()`.

This will also auto-trigger a sync on unpause.