### PR TITLE
CS1-122: Fix percentage value handling

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -396,12 +396,6 @@ func handleBody(
     type: .quantityType(forIdentifier: .bodyFatPercentage)!
   )
   
-  bodyFatPercentage = bodyFatPercentage.map {
-    var copy = $0
-    copy.value = $0.value * 100
-    return copy
-  }
-  
   anchors.appendOptional(bodyMassAnchor)
   anchors.appendOptional(bodyFatPercentageAnchor)
   

--- a/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
@@ -152,7 +152,7 @@ extension QuantitySample {
 
     self.init(
       id: value.uuid.uuidString,
-      value: value.quantity.doubleValue(for: sample.sampleType.toHealthKitUnits),
+      value: doubleValue,
       startDate: sample.startDate,
       endDate: sample.endDate,
       sourceBundle: value.sourceRevision.source.bundleIdentifier,


### PR DESCRIPTION
* Actually used the scaled value.

* Remove the extra *100 scaling for body fat percentage, now that the QuantitySample initializer guarantees that all `HKUnit.percent()` values are scaled from 0...1 to 0...100.