### PR TITLE
VIT-5855: Improve SDK reset behaviour

### DIFF
--- a/Examples/iOS/Settings/Settings.swift
+++ b/Examples/iOS/Settings/Settings.swift
@@ -227,7 +227,7 @@ let settingsReducer = Reducer<Settings.State, Settings.Action, Settings.Environm
 
     case .resetSDK:
       return .task {
-        await VitalHealthKitClient.shared.cleanUp()
+        await VitalClient.shared.signOut()
         return .didResetSDK
       }
 

--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -399,7 +399,7 @@ public let health_secureStorageKey: String = "health_secureStorageKey"
       .filter { $0 == .userNoLongerValid }
       .sink { _ in
         Task {
-          await client.cleanUp()
+          await client.signOut()
         }
       }
       .store(in: &client.cancellables)
@@ -563,8 +563,13 @@ public let health_secureStorageKey: String = "health_secureStorageKey"
     
     storage.storeConnectedSource(for: userId, with: provider)
   }
-  
+
+  @available(*, deprecated, message:"Renamed to `signOut()`.", renamed: "signOut")
   public func cleanUp() async {
+    await signOut()
+  }
+
+  public func signOut() async {
     /// Here we remove the following:
     /// 1) Anchor values we are storing for each `HKSampleType`.
     /// 2) Stage for each `HKSampleType`.

--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -161,6 +161,9 @@ public enum Environment: Equatable, Hashable, Codable, CustomStringConvertible {
 let core_secureStorageKey: String = "core_secureStorageKey"
 let user_secureStorageKey: String = "user_secureStorageKey"
 
+@_spi(VitalSDKInternals)
+public let health_secureStorageKey: String = "health_secureStorageKey"
+
 @objc public class VitalClient: NSObject {
   public static let sdkVersion = "0.11.0"
   
@@ -180,6 +183,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
   private static var client: VitalClient?
   private static let clientInitLock = NSLock()
   private static let automaticConfigurationLock = NSLock()
+  private var cancellables: Set<AnyCancellable> = []
 
   public static var shared: VitalClient {
     let sharedClient = sharedNoAutoConfig
@@ -196,6 +200,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       guard let value = client else {
         let newClient = VitalClient()
         Self.client = newClient
+        Self.bind(newClient, jwtAuth: VitalJWTAuth.live)
         return newClient
       }
 
@@ -314,8 +319,7 @@ let user_secureStorageKey: String = "user_secureStorageKey"
   }
 
   public static var statusDidChange: AnyPublisher<Void, Never> {
-    Publishers.Merge(shared.statusDidChange, shared.jwtAuth.statusDidChange)
-      .eraseToAnyPublisher()
+    shared.statusDidChange.eraseToAnyPublisher()
   }
 
   public static var statuses: AsyncStream<VitalClient.Status> {
@@ -386,6 +390,28 @@ let user_secureStorageKey: String = "user_secureStorageKey"
       /// Bailout, there's nothing else to do here.
       /// (But still try to log it if we have a logger around)
       VitalLogger.core.error("Failed to perform automatic configuration: \(error, privacy: .public)")
+    }
+  }
+
+  private static func bind(_ client: VitalClient, jwtAuth: VitalJWTAuth) {
+    // When JWT detects that a user has been deleted, automatically reset the SDK.
+    jwtAuth.statusDidChange
+      .filter { $0 == .userNoLongerValid }
+      .sink { _ in
+        Task {
+          await client.cleanUp()
+        }
+      }
+      .store(in: &client.cancellables)
+
+    // Asynchronously log Core SDK status changes
+    // NOTE: This must start async. Otherwise, `VitalClient.statuses` will access
+    // `VitalClient.shared` while the initialization lock is still held by the caller of
+    // `bind()`.
+    Task {
+      for await status in type(of: client).statuses {
+        VitalLogger.core.debug("status: \(status, privacy: .public)")
+      }
     }
   }
 
@@ -551,7 +577,8 @@ let user_secureStorageKey: String = "user_secureStorageKey"
 
     self.secureStorage.clean(key: core_secureStorageKey)
     self.secureStorage.clean(key: user_secureStorageKey)
-    
+    self.secureStorage.clean(key: health_secureStorageKey)
+
     self.apiKeyModeUserId.clean()
     self.configuration.clean()
 
@@ -606,7 +633,7 @@ public extension VitalClient {
     case userJwt
   }
 
-  struct Status: OptionSet {
+  struct Status: OptionSet, CustomStringConvertible {
     /// The SDK has been configured, either through `VitalClient.Type.configure` for the first time,
     /// or through `VitalClient.Type.automaticConfiguration()` where the last auto-saved
     /// configuration has been restored.
@@ -633,6 +660,31 @@ public extension VitalClient {
     public static let pendingReauthentication = Status(rawValue: 1 << 4)
 
     public let rawValue: Int
+
+    public var description: String {
+      var texts: [String] = []
+      if self.contains(.configured) {
+        texts.append("configured")
+      }
+      if self.contains(.signedIn) {
+        texts.append("signedIn")
+      }
+      if self.contains(.useApiKey) {
+        texts.append("useApiKey")
+      }
+      if self.contains(.useSignInToken) {
+        texts.append("useSignInToken")
+      }
+      if self.contains(.pendingReauthentication) {
+        texts.append("pendingReauthentication")
+      }
+
+      if texts.isEmpty {
+        return "<not configured>"
+      } else {
+        return texts.joined(separator: ",")
+      }
+    }
 
     public init(rawValue: Int) {
       self.rawValue = rawValue

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -392,7 +392,7 @@ func handleBody(
     type: .quantityType(forIdentifier: .bodyMass)!
   )
   
-  var (bodyFatPercentage, bodyFatPercentageAnchor) = try await queryQuantities(
+  let (bodyFatPercentage, bodyFatPercentageAnchor) = try await queryQuantities(
     type: .quantityType(forIdentifier: .bodyFatPercentage)!
   )
   

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -483,9 +483,10 @@ extension VitalHealthKitClient {
       _status.send(.syncingCompleted)
     }
   }
-  
+
+  @available(*, deprecated, message: "Use `VitalClient.shared.signOut()`, which now resets both the Vital Core and Health SDKs.")
   public func cleanUp() async {
-    await VitalClient.shared.cleanUp()
+    await VitalClient.shared.signOut()
   }
 
   private func resetAutoSync() async {

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -1,7 +1,7 @@
 import HealthKit
 import Combine
 import os.log
-import VitalCore
+@_spi(VitalSDKInternals) import VitalCore
 import UIKit
 
 public enum PermissionOutcome: Equatable {
@@ -9,8 +9,6 @@ public enum PermissionOutcome: Equatable {
   case failure(String)
   case healthKitNotAvailable
 }
-
-let health_secureStorageKey: String = "health_secureStorageKey"
 
 @objc public class VitalHealthKitClient: NSObject {
   public enum Status {
@@ -26,6 +24,7 @@ let health_secureStorageKey: String = "health_secureStorageKey"
       guard let value = client else {
         let newClient = VitalHealthKitClient()
         Self.client = newClient
+        Self.bind(newClient, core: VitalClient.shared)
         return newClient
       }
 
@@ -46,6 +45,10 @@ let health_secureStorageKey: String = "health_secureStorageKey"
   
   private let backgroundDeliveryEnabled: ProtectedBox<Bool> = .init(value: false)
   let configuration: ProtectedBox<Configuration>
+
+  private var isAutoSyncConfigured: Bool {
+    backgroundDeliveryEnabled.value ?? false
+  }
   
   public var status: AnyPublisher<Status, Never> {
     return _status.eraseToAnyPublisher()
@@ -67,6 +70,16 @@ let health_secureStorageKey: String = "health_secureStorageKey"
     self._status = PassthroughSubject<Status, Never>()
     
     super.init()
+  }
+
+  private static func bind(_ client: VitalHealthKitClient, core: VitalClient) {
+    Task {
+      for await status in type(of: core).statuses {
+        if !status.contains(.signedIn) && client.isAutoSyncConfigured {
+          await client.resetAutoSync()
+        }
+      }
+    }
   }
   
   /// Only use this method if you are working from Objc.
@@ -472,14 +485,15 @@ extension VitalHealthKitClient {
   }
   
   public func cleanUp() async {
-    await store.disableBackgroundDelivery()
+    await VitalClient.shared.cleanUp()
+  }
+
+  private func resetAutoSync() async {
     backgroundDeliveryTask?.task.cancel()
     backgroundDeliveryTask = nil
-    
     backgroundDeliveryEnabled.set(value: false)
-    
-    await VitalClient.shared.cleanUp()
-    self.secureStorage.clean(key: health_secureStorageKey)
+
+    await store.disableBackgroundDelivery()
   }
   
   public enum SyncPayload {


### PR DESCRIPTION
* Fixed broken parsing of token refresh error response. `FirebaseTokenRefreshErrorResponse` should be used instead of `FirebaseTokenRefreshError`.

* If the signed-in user is deleted, the SDK now self-resets as if `VitalHealthKitClient.shared.cleanUp()` is called.

* Resetting the Core SDK also resets the Health SDK auto-sync.