### PR TITLE
VIT-5976: Don't rely on VitalClient.status to reset Health SDK

### DIFF
--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -185,6 +185,9 @@ public let health_secureStorageKey: String = "health_secureStorageKey"
   private static let automaticConfigurationLock = NSLock()
   private var cancellables: Set<AnyCancellable> = []
 
+  @_spi(VitalSDKInternals)
+  public let childSDKShouldReset = PassthroughSubject<Void, Never>()
+
   public static var shared: VitalClient {
     let sharedClient = sharedNoAutoConfig
 
@@ -587,6 +590,7 @@ public let health_secureStorageKey: String = "health_secureStorageKey"
     self.apiKeyModeUserId.clean()
     self.configuration.clean()
 
+    childSDKShouldReset.send(())
     statusDidChange.send(())
   }
 


### PR DESCRIPTION
Reset child SDKs only when we explicitly detect user invalidation via JWT Auth, or consumer app explicitly calling `signOut()`.

Stop relying on `VitalClient.status` to reset the Health SDK. This is because `VitalClient.status` can report a false negative "signed out" state when Keychain is inaccessible until first unlock.

Vital SDK client secrets are stored in the iOS Keychain.