### PR TITLE
VIT-6473: Refactor HealthKit -> Vital Resource mapping

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -139,13 +139,13 @@ func read(
   switch resource {
     case .individual:
       
-      let types = toHealthKitTypes(resource: resource)
-      guard types.count == 1 else {
+      let requirements = toHealthKitTypes(resource: resource)
+    guard requirements.isIndividualType else {
         fatalError("Individual types should made up of a single type. \(resource) isn't. This is a developer error")
       }
       
-      guard let sampleType = types.first as? HKSampleType else {
-        fatalError("\(types) is not an HKSampleType")
+      guard let sampleType = requirements.required.first as? HKSampleType else {
+        fatalError("\(requirements.required.first!) is not an HKSampleType")
       }
       
       return try await read(

--- a/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
@@ -1,134 +1,143 @@
 import HealthKit
 import VitalCore
 
-func toHealthKitTypes(resource: VitalResource) -> Set<HKObjectType> {
+struct HealthKitObjectTypeRequirements {
+  /// The required set of HKObjectTypes of a `VitalResource`.
+  ///
+  /// This must not change once the `VitalResource` is introduced, especially if
+  /// the `VitalResource` is a fully computed resource like `activity`.
+  let required: Set<HKObjectType>
+
+  /// An optional set of HKObjectTypes of a `VitalResource`.
+  /// New types can be added or removed from this list.
+  let optional: Set<HKObjectType>
+
+  var isIndividualType: Bool {
+    required.count == 1 && optional.isEmpty
+  }
+
+  func isResourceActive(_ query: (HKObjectType) -> Bool) -> Bool {
+    return self.required.allSatisfy(query) && (
+      self.optional.isEmpty || self.optional.contains(where: query)
+    )
+  }
+}
+
+private func single(_ type: HKObjectType) -> HealthKitObjectTypeRequirements {
+  return HealthKitObjectTypeRequirements(required: [type], optional: [])
+}
+
+func toHealthKitTypes(resource: VitalResource) -> HealthKitObjectTypeRequirements {
   switch resource {
-    case .individual(.steps):
-      return [
-        HKSampleType.quantityType(forIdentifier: .stepCount)!,
-      ]
-    case .individual(.activeEnergyBurned):
-      return [
-        HKSampleType.quantityType(forIdentifier: .activeEnergyBurned)!,
-      ]
-    case .individual(.basalEnergyBurned):
-      return [
-        HKSampleType.quantityType(forIdentifier: .basalEnergyBurned)!,
-      ]
-    case .individual(.floorsClimbed):
-      return [
-        HKSampleType.quantityType(forIdentifier: .flightsClimbed)!,
-      ]
-    case .individual(.distanceWalkingRunning):
-      return [
-        HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!,
-      ]
-    case .individual(.vo2Max):
-      return [
-        HKSampleType.quantityType(forIdentifier: .vo2Max)!,
-      ]
-    case .individual(.exerciseTime):
-      return [
-        HKSampleType.quantityType(forIdentifier: .appleExerciseTime)!,
-      ]
-    case .individual(.weight):
-      return [
-        HKSampleType.quantityType(forIdentifier: .bodyMass)!,
-      ]
-    case .individual(.bodyFat):
-      return [
-        HKSampleType.quantityType(forIdentifier: .bodyFatPercentage)!,
-      ]
-    case .vitals(.bloodOxygen):
-      return [
-        HKSampleType.quantityType(forIdentifier: .oxygenSaturation)!,
-      ]
-      
-    case .profile:
-      return [
+  case .individual(.steps):
+    return single(HKSampleType.quantityType(forIdentifier: .stepCount)!)
+  case .individual(.activeEnergyBurned):
+    return single(HKSampleType.quantityType(forIdentifier: .activeEnergyBurned)!)
+  case .individual(.basalEnergyBurned):
+    return single(HKSampleType.quantityType(forIdentifier: .basalEnergyBurned)!)
+  case .individual(.floorsClimbed):
+    return single(HKSampleType.quantityType(forIdentifier: .flightsClimbed)!)
+  case .individual(.distanceWalkingRunning):
+    return single(HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!)
+  case .individual(.vo2Max):
+    return single(HKSampleType.quantityType(forIdentifier: .vo2Max)!)
+  case .individual(.exerciseTime):
+    return single(HKSampleType.quantityType(forIdentifier: .appleExerciseTime)!)
+  case .individual(.weight):
+    return single(HKSampleType.quantityType(forIdentifier: .bodyMass)!)
+  case .individual(.bodyFat):
+    return single(HKSampleType.quantityType(forIdentifier: .bodyFatPercentage)!)
+  case .vitals(.bloodOxygen):
+    return single(HKSampleType.quantityType(forIdentifier: .oxygenSaturation)!)
+
+  case .profile:
+    return HealthKitObjectTypeRequirements(
+      required: [],
+      optional: [
         HKCharacteristicType.characteristicType(forIdentifier: .biologicalSex)!,
         HKCharacteristicType.characteristicType(forIdentifier: .dateOfBirth)!,
         HKQuantityType.quantityType(forIdentifier: .height)!,
       ]
+    )
 
-    case .body:
-      
-      return toHealthKitTypes(resource: .individual(.bodyFat)) +
-      toHealthKitTypes(resource: .individual(.weight))
-      
-    case .sleep:
-      let temperature: Set<HKObjectType>
-      if #available(iOS 16.0, *) {
-        temperature = [HKSampleType.quantityType(forIdentifier: .appleSleepingWristTemperature)!]
-      } else {
-        temperature = []
-      }
+  case .body:
+    return HealthKitObjectTypeRequirements(required: [], optional: [
+      HKSampleType.quantityType(forIdentifier: .bodyFatPercentage)!,
+      HKSampleType.quantityType(forIdentifier: .bodyMass)!,
+    ])
 
-      return [
+  case .sleep:
+    let temperature: Set<HKObjectType>
+    if #available(iOS 16.0, *) {
+      temperature = [HKSampleType.quantityType(forIdentifier: .appleSleepingWristTemperature)!]
+    } else {
+      temperature = []
+    }
+
+    return HealthKitObjectTypeRequirements(
+      required: [
         HKSampleType.categoryType(forIdentifier: .sleepAnalysis)!,
+      ],
+      optional: [
         HKSampleType.quantityType(forIdentifier: .heartRate)!,
         HKSampleType.quantityType(forIdentifier: .heartRateVariabilitySDNN)!,
         HKSampleType.quantityType(forIdentifier: .oxygenSaturation)!,
-        HKSampleType.quantityType(forIdentifier: .restingHeartRate)!, 
+        HKSampleType.quantityType(forIdentifier: .restingHeartRate)!,
         HKSampleType.quantityType(forIdentifier: .respiratoryRate)!,
       ] + temperature
-      
-    case .activity:
-      let base = toHealthKitTypes(resource: .individual(.steps)) +
-      toHealthKitTypes(resource: .individual(.floorsClimbed)) +
-      toHealthKitTypes(resource: .individual(.basalEnergyBurned)) +
-      toHealthKitTypes(resource: .individual(.activeEnergyBurned)) +
-      toHealthKitTypes(resource: .individual(.distanceWalkingRunning)) +
-      toHealthKitTypes(resource: .individual(.vo2Max))
+    )
 
-      return base + [
+  case .activity:
+
+    return HealthKitObjectTypeRequirements(
+      required: [], optional: [
+        HKSampleType.quantityType(forIdentifier: .stepCount)!,
+        HKSampleType.quantityType(forIdentifier: .basalEnergyBurned)!,
+        HKSampleType.quantityType(forIdentifier: .activeEnergyBurned)!,
+        HKSampleType.quantityType(forIdentifier: .flightsClimbed)!,
+        HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!,
+        HKSampleType.quantityType(forIdentifier: .vo2Max)!,
         HKSampleType.quantityType(forIdentifier: .heartRate)!,
         HKSampleType.quantityType(forIdentifier: .restingHeartRate)!,
         HKSampleType.quantityType(forIdentifier: .appleExerciseTime)!
       ]
+    )
 
-    case .workout:
-      return [
-        HKSampleType.workoutType(),
+  case .workout:
+    return HealthKitObjectTypeRequirements(
+      required: [HKSampleType.workoutType()],
+      optional: [
         HKSampleType.quantityType(forIdentifier: .heartRate)!,
         HKSampleType.quantityType(forIdentifier: .respiratoryRate)!
       ]
-      
-    case .vitals(.glucose):
-      return [
-        HKSampleType.quantityType(forIdentifier: .bloodGlucose)!
-      ]
-      
-    case .vitals(.bloodPressure):
-      return [
+    )
+
+  case .vitals(.glucose):
+    return single(HKSampleType.quantityType(forIdentifier: .bloodGlucose)!)
+
+  case .vitals(.bloodPressure):
+    return HealthKitObjectTypeRequirements(
+      required: [
         HKSampleType.quantityType(forIdentifier: .bloodPressureSystolic)!,
-        HKSampleType.quantityType(forIdentifier: .bloodPressureDiastolic)!
-      ]
-      
-    case .vitals(.heartRate):
-      return [
-        HKSampleType.quantityType(forIdentifier: .heartRate)!
-      ]
-      
-    case .nutrition(.water):
-      return [
-        .quantityType(forIdentifier: .dietaryWater)!
-      ]
+        HKSampleType.quantityType(forIdentifier: .bloodPressureDiastolic)!,
+      ],
+      optional: []
+    )
 
-    case .nutrition(.caffeine):
-      return [
-        .quantityType(forIdentifier: .dietaryCaffeine)!
-      ]
+  case .vitals(.heartRate):
+    return single(HKSampleType.quantityType(forIdentifier: .heartRate)!)
 
-    case .vitals(.mindfulSession):
-      return [
-        .categoryType(forIdentifier: .mindfulSession)!
-      ]
+  case .nutrition(.water):
+    return single(.quantityType(forIdentifier: .dietaryWater)!)
 
-    case .vitals(.heartRateVariability):
-      return [
-        .quantityType(forIdentifier: .heartRateVariabilitySDNN)!
-      ]
+  case .nutrition(.caffeine):
+    return single(.quantityType(forIdentifier: .dietaryCaffeine)!)
+
+  case .vitals(.mindfulSession):
+    return single(.categoryType(forIdentifier: .mindfulSession)!)
+
+  case .vitals(.heartRateVariability):
+    return single(.quantityType(forIdentifier: .heartRateVariabilitySDNN)!)
   }
 }
 
@@ -221,9 +230,7 @@ func resourcesAskedForPermission(
   var resources: [VitalResource] = []
   
   for resource in VitalResource.all {
-    guard toHealthKitTypes(resource: resource).isEmpty == false else {
-      continue
-    }
+    let requirements = toHealthKitTypes(resource: resource)
     
     let hasAskedPermission = store.hasAskedForPermission(resource)
     

--- a/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
@@ -17,9 +17,11 @@ struct HealthKitObjectTypeRequirements {
   }
 
   func isResourceActive(_ query: (HKObjectType) -> Bool) -> Bool {
-    return self.required.allSatisfy(query) && (
-      self.optional.isEmpty || self.optional.contains(where: query)
-    )
+    if self.required.isEmpty {
+      return self.optional.contains(where: query)
+    } else {
+      return self.required.allSatisfy(query)
+    }
   }
 }
 

--- a/Sources/VitalHealthKit/HealthKit/Models/WritableVitalResource.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/WritableVitalResource.swift
@@ -24,8 +24,8 @@ public enum DataInput {
   }
   
   var type: HKQuantityType {
-    let types = toHealthKitTypes(resource: resource)
-    guard let type = types.first as? HKQuantityType else {
+    let requirements = toHealthKitTypes(resource: resource)
+    guard requirements.isIndividualType, let type = requirements.required.first as? HKQuantityType else {
       fatalError("This is a developer error. No type for \(self)")
     }
     

--- a/Tests/VitalHealthKitTests/SampleTypeTests.swift
+++ b/Tests/VitalHealthKitTests/SampleTypeTests.swift
@@ -103,4 +103,95 @@ class SampleTypeTests: XCTestCase {
     }
   }
 
+  @available(iOS 15.0, *)
+  func test_HealthKitObjectTypeRequirements_singleObjectType() {
+    let requirements = HealthKitObjectTypeRequirements(
+      required: [HKQuantityType(.appleExerciseTime)],
+      optional: []
+    )
+
+    // required[0] has been asked
+    XCTAssertTrue(requirements.isResourceActive { _ in true })
+
+    // required[0] has not been asked
+    XCTAssertFalse(requirements.isResourceActive { _ in false })
+  }
+
+  @available(iOS 15.0, *)
+  func test_HealthKitObjectTypeRequirements_multipleRequiredObjectTypes() {
+    let requirements = HealthKitObjectTypeRequirements(
+      required: [
+        HKQuantityType(.appleExerciseTime),
+        HKQuantityType(.appleMoveTime),
+        HKQuantityType(.appleStandTime),
+      ],
+      optional: []
+    )
+
+    // All asked
+    XCTAssertTrue(requirements.isResourceActive { _ in true })
+
+    // All asked, except for .appleStandTime
+    XCTAssertFalse(requirements.isResourceActive { type in type != HKQuantityType(.appleStandTime) })
+
+    // All have not been asked
+    XCTAssertFalse(requirements.isResourceActive { _ in false })
+  }
+
+  @available(iOS 15.0, *)
+  func test_HealthKitObjectTypeRequirements_SomeRequiredSomeOptionalTypes() {
+    let requirements = HealthKitObjectTypeRequirements(
+      required: [
+        HKQuantityType(.appleExerciseTime),
+        HKQuantityType(.appleMoveTime),
+      ],
+      optional: [
+        HKQuantityType(.appleStandTime),
+      ]
+    )
+
+    // All asked
+    XCTAssertTrue(requirements.isResourceActive { _ in true })
+
+    // Only appleExerciseTime has been asked
+    XCTAssertFalse(requirements.isResourceActive { type in type == HKQuantityType(.appleExerciseTime) })
+
+    // All except appleStandTime have been asked
+    XCTAssertTrue(requirements.isResourceActive { type in type != HKQuantityType(.appleStandTime) })
+
+    // All have not been asked
+    XCTAssertFalse(requirements.isResourceActive { _ in false })
+  }
+
+  @available(iOS 15.0, *)
+  func test_HealthKitObjectTypeRequirements_noRequiredMultipleOptionalTypes() {
+    let requirements = HealthKitObjectTypeRequirements(
+      required: [],
+      optional: [
+        HKQuantityType(.appleExerciseTime),
+        HKQuantityType(.appleMoveTime),
+        HKQuantityType(.appleStandTime),
+      ]
+    )
+
+    // All asked
+    XCTAssertTrue(requirements.isResourceActive { _ in true })
+
+    // Only .appleStandTime has been asked
+    XCTAssertTrue(requirements.isResourceActive { type in type == HKQuantityType(.appleStandTime) })
+
+    // All have not been asked
+    XCTAssertFalse(requirements.isResourceActive { _ in false })
+  }
+
+  @available(iOS 15.0, *)
+  func test_HealthKitObjectTypeRequirements_empty() {
+    let requirements = HealthKitObjectTypeRequirements(
+      required: [],
+      optional: []
+    )
+
+    XCTAssertFalse(requirements.isResourceActive { _ in true })
+    XCTAssertFalse(requirements.isResourceActive { _ in false })
+  }
 }


### PR DESCRIPTION
Correctly model the HealthKit types -> VitalResource relationship as two tiers:
* a **required** `HKObjectType` set
* an optional `HKObjectType` set

This ensures that when we add more `HKObjectType`s into an existing composite resource like `activity`, we do not break the composite resource mapping just because permissions have never been requested on the new `HKObjectType`s.