### PR TITLE
VIT-6512: HealthKit: Fix historical fetch resource remapping

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
@@ -227,17 +227,14 @@ func observedSampleTypes() -> [[HKSampleType]] {
 
 func resourcesAskedForPermission(
   store: VitalHealthKitStore
-) -> [VitalResource] {
-  
-  var resources: [VitalResource] = []
-  
+) -> Set<VitalResource> {
+
+  var resources: Set<VitalResource> = []
+
   for resource in VitalResource.all {
-    let requirements = toHealthKitTypes(resource: resource)
-    
     let hasAskedPermission = store.hasAskedForPermission(resource)
-    
     if hasAskedPermission {
-      resources.append(resource)
+      resources.insert(resource)
     }
   }
   

--- a/Tests/VitalHealthKitTests/SampleTypeTests.swift
+++ b/Tests/VitalHealthKitTests/SampleTypeTests.swift
@@ -52,36 +52,26 @@ class SampleTypeTests: XCTestCase {
 
     Task {
       do {
-        for hasAskedForPermission in [true, false] {
-          for sampleType in observedSampleTypes().flatMap({ $0 }) {
-            let permission: (VitalResource) -> Bool = { _ in hasAskedForPermission }
+        for sampleType in observedSampleTypes().flatMap({ $0 }) {
+          let resource = VitalHealthKitStore.sampleTypeToVitalResource(type: sampleType)
 
-            let resource = VitalHealthKitStore.sampleTypeToVitalResource(
-              hasAskedForPermission: permission,
-              type: sampleType
+          do {
+            _ = try await read(
+              resource: resource,
+              healthKitStore: MockHealthStore(),
+              typeToResource: {
+                VitalHealthKitStore.sampleTypeToVitalResource(type: $0)
+              },
+              vitalStorage: .init(storage: .debug),
+              startDate: Date(),
+              endDate: Date()
             )
-
-            do {
-              _ = try await read(
-                resource: resource,
-                healthKitStore: MockHealthStore(),
-                typeToResource: {
-                  VitalHealthKitStore.sampleTypeToVitalResource(
-                    hasAskedForPermission: permission,
-                    type: $0
-                  )
-                },
-                vitalStorage: .init(storage: .debug),
-                startDate: Date(),
-                endDate: Date()
-              )
-            } catch let error {
-              switch error {
-              case is ExpectedError:
-                continue
-              default:
-                throw error
-              }
+          } catch let error {
+            switch error {
+            case is ExpectedError:
+              continue
+            default:
+              throw error
             }
           }
         }


### PR DESCRIPTION
#120 addressed the mapping design issue itself, and fixed issues when we map background delivery callbacks (in terms of `HKSampleType`) to an actionable VitalResource.

However, the historical stage was not addressed. We are still calling `VitalHealthKitClient.sync(_:)` on all individual resources (e.g. steps, vo2max) **in addition to** the composite resource (e.g. activity). We are supposed to only sync the composite resources (which as an umbrella syncs all the related individual resources).

This PR does further refactoring to ensure that the `sync(_:)` now accepts only **remapped resources** at compile time. Notably with this change, the iOS SDK is now fully aligned with Android SDK on how individual->composite resource remapping is handled.