### PR TITLE
VIT-6572: Overhaul how the time range to recompute hourly statistics is being decided

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
+++ b/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
@@ -64,14 +64,16 @@ class VitalHealthKitStorage {
     {
       storage.store(data, anchorPrefix)
     }
-    
+
     if
       let anchors = entity.vitalAnchors,
       let data = try? JSONEncoder().encode(anchors)
     {
       storage.store(data, anchorsPrefix)
+    } else {
+      storage.remove(anchorsPrefix)
     }
-    
+
     if let date = entity.date {
       storage.storeDate(date, datePrefix)
     }


### PR DESCRIPTION
The new approach:

1. Ask HealthKit to return all newly inserted (`HKQuantitySample`s) since we last queried.
    * via `HKAnchoredObjectQuery`.
3. Takes the min-max of all sample timestamps, and then align the min-max to whole hours.
4. Recompute  steps/calories/etc hourly statistics of this time range.

This replaces the existing brute force approach of:

1. constantly querying 7 days of hourly statistics, wasting CPU time; and 
2. having to store hashes of the output statistics in order to deduplicate what we send to the backend.

TODO: Verify how SDK behaves when upgrading from an older version.