### PR TITLE
VIT-6573: Opt-in device-specific activity timeseries

### DIFF
--- a/Sources/VitalCore/Core/Client/Data Models/Base Models/UserCRUD.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Base Models/UserCRUD.swift
@@ -30,6 +30,22 @@ public struct UserSDKSyncStateResponse: Decodable {
   public let status: Status
   public let requestStartDate: Date?
   public let requestEndDate: Date?
+  public var perDeviceActivityTS: Bool = false
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.status = try container.decode(Status.self, forKey: .status)
+    self.requestStartDate = try container.decodeIfPresent(Date.self, forKey: .requestStartDate)
+    self.requestEndDate = try container.decodeIfPresent(Date.self, forKey: .requestEndDate)
+    self.perDeviceActivityTS = try container.decodeIfPresent(Bool.self, forKey: .perDeviceActivityTS) ?? false
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case status = "status"
+    case requestStartDate = "request_start_date"
+    case requestEndDate = "request_end_date"
+    case perDeviceActivityTS = "per_device_activity_ts"
+  }
 }
 
 public enum Stage: String, Encodable {
@@ -42,7 +58,7 @@ public struct UserSDKSyncStateBody: Encodable {
   public let tzinfo: String
   public let requestStartDate: Date?
   public let requestEndDate: Date?
-  
+
   public init(stage: Stage, tzinfo: String, requestStartDate: Date? = nil, requestEndDate: Date? = nil) {
     self.stage = stage
     self.tzinfo = tzinfo

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -559,7 +559,8 @@ extension VitalHealthKitClient {
         remappedResource,
         startDateInBounds,
         endDateInBounds,
-        storage
+        storage,
+        ReadOptions(perDeviceActivityTS: statusResponse.perDeviceActivityTS)
       )
 
       guard let data = data, data.shouldSkipPost == false else {
@@ -681,7 +682,8 @@ extension VitalHealthKitClient {
       typeToResource: VitalHealthKitStore.live.toVitalResource,
       vitalStorage: VitalHealthKitStorage(storage: .debug),
       startDate: startDate,
-      endDate: endDate
+      endDate: endDate,
+      options: ReadOptions()
     )
 
     if let data = data {

--- a/Tests/VitalHealthKitTests/SampleTypeTests.swift
+++ b/Tests/VitalHealthKitTests/SampleTypeTests.swift
@@ -64,7 +64,8 @@ class SampleTypeTests: XCTestCase {
               },
               vitalStorage: .init(storage: .debug),
               startDate: Date(),
-              endDate: Date()
+              endDate: Date(),
+              options: ReadOptions()
             )
           } catch let error {
             switch error {
@@ -86,8 +87,12 @@ class SampleTypeTests: XCTestCase {
   }
 
   func test_all_quantity_sample_types_have_mapped_unit() async {
-    for sampleType in VitalResource.all.flatMap(toHealthKitTypes(resource:)) {
-      guard let sampleType = sampleType as? HKQuantityType else { continue }
+    let allQuantityTypes = VitalResource.all
+      .map(toHealthKitTypes(resource:))
+      .flatMap { $0.required + $0.optional }
+      .compactMap { $0 as? HKQuantityType }
+
+    for sampleType in allQuantityTypes {
       _ = sampleType.toHealthKitUnits
       _ = sampleType.toUnitStringRepresentation
     }


### PR DESCRIPTION
This PR adds an opt-in, backend-controlled feature flag `per_device_activity_ts`.

If enabled, the SDK would send the device-specific activity timeseries data (`type = phone | watch | unknown | etc`), in addition to the hourly statistics (marked with `type = multiple_sources`).

By coincidence, the new hourly statistics approach (#123) already discovers new device-specific activity samples as a byproduct. So to implement this feature, we don't need to do much more, besides embedding these already-available data in the outgoing payload.