### PR TITLE
VIT-6561: Include a vendored copy of swift-log@1.5.4

### DIFF
--- a/Examples/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -128,15 +128,6 @@
         }
       },
       {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-          "version": "1.5.4"
-        }
-      },
-      {
         "package": "swiftui-navigation",
         "repositoryURL": "https://github.com/pointfreeco/swiftui-navigation",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,6 @@ let package = Package(
       targets: ["VitalCore"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     .package(name: "CombineCoreBluetooth", url: "https://github.com/StarryInternet/CombineCoreBluetooth.git", from: "0.3.0"),
     .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.6.0")),
   ],
@@ -38,12 +37,16 @@ let package = Package(
     ),
     .target(
       name: "VitalCore",
-      dependencies: [.product(name: "Logging", package: "swift-log")],
+      dependencies: ["VitalLogging"],
       exclude: [
         "./Get/LICENSE",
         "./DataCompression/LICENSE",
         "./Keychain/LICENSE"
       ]
+    ),
+    .target(
+      name: "VitalLogging",
+      exclude: ["./LICENSE.txt", "./README.txt"]
     ),
     .testTarget(
       name: "VitalHealthKitTests",

--- a/Sources/VitalCore/Core/Logs/VitalLogger.swift
+++ b/Sources/VitalCore/Core/Logs/VitalLogger.swift
@@ -1,12 +1,12 @@
-import Logging
+import VitalLogging
 import Foundation
 
 public enum VitalLogger {
   public static let subsystem = "io.tryvital.vital-ios"
 
-  public static let core = Logging.Logger(label: Category.core.rawValue, factory: Self.logHandlerFactory)
-  public static let requests = Logging.Logger(label: Category.requests.rawValue, factory: Self.logHandlerFactory)
-  public static let healthKit = Logging.Logger(label: Category.healthKit.rawValue, factory: Self.logHandlerFactory)
+  public static let core = VitalLogging.Logger(label: Category.core.rawValue, factory: Self.logHandlerFactory)
+  public static let requests = VitalLogging.Logger(label: Category.requests.rawValue, factory: Self.logHandlerFactory)
+  public static let healthKit = VitalLogging.Logger(label: Category.healthKit.rawValue, factory: Self.logHandlerFactory)
 
   public enum Category: String {
     case core
@@ -15,7 +15,7 @@ public enum VitalLogger {
     case requestBody
   }
 
-  private static func logHandlerFactory(label: String) -> Logging.LogHandler {
+  private static func logHandlerFactory(label: String) -> VitalLogging.LogHandler {
     MultiplexLogHandler([
       StreamLogHandler.standardOutput(label: label),
       VitalPersistentLoggerWrapper(label: label),
@@ -24,26 +24,26 @@ public enum VitalLogger {
 }
 
 
-private struct VitalPersistentLoggerWrapper: Logging.LogHandler {
+private struct VitalPersistentLoggerWrapper: VitalLogging.LogHandler {
 
   var category: VitalLogger.Category
 
-  var metadata = Logging.Logger.Metadata()
-  var logLevel: Logging.Logger.Level = .info
+  var metadata = VitalLogging.Logger.Metadata()
+  var logLevel: VitalLogging.Logger.Level = .info
 
   init(label: String) {
     self.category = VitalLogger.Category(rawValue: label)!
   }
 
-  subscript(metadataKey metadataKey: String) -> Logging.Logger.Metadata.Value? {
+  subscript(metadataKey metadataKey: String) -> VitalLogging.Logger.Metadata.Value? {
       get { return self.metadata[metadataKey] }
       set { self.metadata[metadataKey] = newValue }
   }
 
   func log(
-    level: Logging.Logger.Level,
-    message: Logging.Logger.Message,
-    metadata: Logging.Logger.Metadata?,
+    level: VitalLogging.Logger.Level,
+    message: VitalLogging.Logger.Message,
+    metadata: VitalLogging.Logger.Metadata?,
     source: String,
     file: String,
     function: String,

--- a/Sources/VitalLogging/LICENSE.txt
+++ b/Sources/VitalLogging/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Sources/VitalLogging/Locks.swift
+++ b/Sources/VitalLogging/Locks.swift
@@ -1,0 +1,287 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Logging API open source project
+//
+// Copyright (c) 2018-2019 Apple Inc. and the Swift Logging API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(WASILibc)
+// No locking on WASILibc
+#elseif canImport(Darwin)
+import Darwin
+#elseif os(Windows)
+import WinSDK
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("Unsupported runtime")
+#endif
+
+/// A threading lock based on `libpthread` instead of `libdispatch`.
+///
+/// This object provides a lock on top of a single `pthread_mutex_t`. This kind
+/// of lock is safe to use with `libpthread`-based threading models, such as the
+/// one used by NIO. On Windows, the lock is based on the substantially similar
+/// `SRWLOCK` type.
+internal final class Lock {
+    #if canImport(WASILibc)
+    // WASILibc is single threaded, provides no locks
+    #elseif os(Windows)
+    fileprivate let mutex: UnsafeMutablePointer<SRWLOCK> =
+        UnsafeMutablePointer.allocate(capacity: 1)
+    #else
+    fileprivate let mutex: UnsafeMutablePointer<pthread_mutex_t> =
+        UnsafeMutablePointer.allocate(capacity: 1)
+    #endif
+
+    /// Create a new lock.
+    public init() {
+        #if canImport(WASILibc)
+        // WASILibc is single threaded, provides no locks
+        #elseif os(Windows)
+        InitializeSRWLock(self.mutex)
+        #else
+        var attr = pthread_mutexattr_t()
+        pthread_mutexattr_init(&attr)
+        pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK))
+
+        let err = pthread_mutex_init(self.mutex, &attr)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+
+    deinit {
+        #if canImport(WASILibc)
+        // WASILibc is single threaded, provides no locks
+        #elseif os(Windows)
+        // SRWLOCK does not need to be free'd
+        self.mutex.deallocate()
+        #else
+        let err = pthread_mutex_destroy(self.mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        self.mutex.deallocate()
+        #endif
+    }
+
+    /// Acquire the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `unlock`, to simplify lock handling.
+    public func lock() {
+        #if canImport(WASILibc)
+        // WASILibc is single threaded, provides no locks
+        #elseif os(Windows)
+        AcquireSRWLockExclusive(self.mutex)
+        #else
+        let err = pthread_mutex_lock(self.mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+
+    /// Release the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `lock`, to simplify lock handling.
+    public func unlock() {
+        #if canImport(WASILibc)
+        // WASILibc is single threaded, provides no locks
+        #elseif os(Windows)
+        ReleaseSRWLockExclusive(self.mutex)
+        #else
+        let err = pthread_mutex_unlock(self.mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+}
+
+extension Lock {
+    /// Acquire the lock for the duration of the given block.
+    ///
+    /// This convenience method should be preferred to `lock` and `unlock` in
+    /// most situations, as it ensures that the lock will be released regardless
+    /// of how `body` exits.
+    ///
+    /// - Parameter body: The block to execute while holding the lock.
+    /// - Returns: The value returned by the block.
+    @inlinable
+    internal func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.lock()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+
+    // specialise Void return (for performance)
+    @inlinable
+    internal func withLockVoid(_ body: () throws -> Void) rethrows {
+        try self.withLock(body)
+    }
+}
+
+/// A reader/writer threading lock based on `libpthread` instead of `libdispatch`.
+///
+/// This object provides a lock on top of a single `pthread_rwlock_t`. This kind
+/// of lock is safe to use with `libpthread`-based threading models, such as the
+/// one used by NIO. On Windows, the lock is based on the substantially similar
+/// `SRWLOCK` type.
+internal final class ReadWriteLock {
+    #if canImport(WASILibc)
+    // WASILibc is single threaded, provides no locks
+    #elseif os(Windows)
+    fileprivate let rwlock: UnsafeMutablePointer<SRWLOCK> =
+        UnsafeMutablePointer.allocate(capacity: 1)
+    fileprivate var shared: Bool = true
+    #else
+    fileprivate let rwlock: UnsafeMutablePointer<pthread_rwlock_t> =
+        UnsafeMutablePointer.allocate(capacity: 1)
+    #endif
+
+    /// Create a new lock.
+    public init() {
+        #if canImport(WASILibc)
+        // WASILibc is single threaded, provides no locks
+        #elseif os(Windows)
+        InitializeSRWLock(self.rwlock)
+        #else
+        let err = pthread_rwlock_init(self.rwlock, nil)
+        precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
+        #endif
+    }
+
+    deinit {
+        #if canImport(WASILibc)
+        // WASILibc is single threaded, provides no locks
+        #elseif os(Windows)
+        // SRWLOCK does not need to be free'd
+        self.rwlock.deallocate()
+        #else
+        let err = pthread_rwlock_destroy(self.rwlock)
+        precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
+        self.rwlock.deallocate()
+        #endif
+    }
+
+    /// Acquire a reader lock.
+    ///
+    /// Whenever possible, consider using `withReaderLock` instead of this
+    /// method and `unlock`, to simplify lock handling.
+    public func lockRead() {
+        #if canImport(WASILibc)
+        // WASILibc is single threaded, provides no locks
+        #elseif os(Windows)
+        AcquireSRWLockShared(self.rwlock)
+        self.shared = true
+        #else
+        let err = pthread_rwlock_rdlock(self.rwlock)
+        precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
+        #endif
+    }
+
+    /// Acquire a writer lock.
+    ///
+    /// Whenever possible, consider using `withWriterLock` instead of this
+    /// method and `unlock`, to simplify lock handling.
+    public func lockWrite() {
+        #if canImport(WASILibc)
+        // WASILibc is single threaded, provides no locks
+        #elseif os(Windows)
+        AcquireSRWLockExclusive(self.rwlock)
+        self.shared = false
+        #else
+        let err = pthread_rwlock_wrlock(self.rwlock)
+        precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
+        #endif
+    }
+
+    /// Release the lock.
+    ///
+    /// Whenever possible, consider using `withReaderLock` and `withWriterLock`
+    /// instead of this method and `lockRead` and `lockWrite`, to simplify lock
+    /// handling.
+    public func unlock() {
+        #if canImport(WASILibc)
+        // WASILibc is single threaded, provides no locks
+        #elseif os(Windows)
+        if self.shared {
+            ReleaseSRWLockShared(self.rwlock)
+        } else {
+            ReleaseSRWLockExclusive(self.rwlock)
+        }
+        #else
+        let err = pthread_rwlock_unlock(self.rwlock)
+        precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
+        #endif
+    }
+}
+
+extension ReadWriteLock {
+    /// Acquire the reader lock for the duration of the given block.
+    ///
+    /// This convenience method should be preferred to `lockRead` and `unlock`
+    /// in most situations, as it ensures that the lock will be released
+    /// regardless of how `body` exits.
+    ///
+    /// - Parameter body: The block to execute while holding the reader lock.
+    /// - Returns: The value returned by the block.
+    @inlinable
+    internal func withReaderLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.lockRead()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+
+    /// Acquire the writer lock for the duration of the given block.
+    ///
+    /// This convenience method should be preferred to `lockWrite` and `unlock`
+    /// in most situations, as it ensures that the lock will be released
+    /// regardless of how `body` exits.
+    ///
+    /// - Parameter body: The block to execute while holding the writer lock.
+    /// - Returns: The value returned by the block.
+    @inlinable
+    internal func withWriterLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.lockWrite()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+
+    // specialise Void return (for performance)
+    @inlinable
+    internal func withReaderLockVoid(_ body: () throws -> Void) rethrows {
+        try self.withReaderLock(body)
+    }
+
+    // specialise Void return (for performance)
+    @inlinable
+    internal func withWriterLockVoid(_ body: () throws -> Void) rethrows {
+        try self.withWriterLock(body)
+    }
+}

--- a/Sources/VitalLogging/LogHandler.swift
+++ b/Sources/VitalLogging/LogHandler.swift
@@ -1,0 +1,219 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Logging API open source project
+//
+// Copyright (c) 2018-2019 Apple Inc. and the Swift Logging API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A `LogHandler` is an implementation of a logging backend.
+///
+/// This type is an implementation detail and should not normally be used, unless implementing your own logging backend.
+/// To use the SwiftLog API, please refer to the documentation of ``Logger``.
+///
+/// # Implementation requirements
+///
+/// To implement your own `LogHandler` you should respect a few requirements that are necessary so applications work
+/// as expected regardless of the selected `LogHandler` implementation.
+///
+/// - The ``LogHandler`` must be a `struct`.
+/// - The metadata and `logLevel` properties must be implemented so that setting them on a `Logger` does not affect
+///   other `Logger`s.
+///
+/// ### Treat log level & metadata as values
+///
+/// When developing your `LogHandler`, please make sure the following test works.
+///
+/// ```swift
+/// LoggingSystem.bootstrap(MyLogHandler.init) // your LogHandler might have a different bootstrapping step
+/// var logger1 = Logger(label: "first logger")
+/// logger1.logLevel = .debug
+/// logger1[metadataKey: "only-on"] = "first"
+///
+/// var logger2 = logger1
+/// logger2.logLevel = .error                  // this must not override `logger1`'s log level
+/// logger2[metadataKey: "only-on"] = "second" // this must not override `logger1`'s metadata
+///
+/// XCTAssertEqual(.debug, logger1.logLevel)
+/// XCTAssertEqual(.error, logger2.logLevel)
+/// XCTAssertEqual("first", logger1[metadataKey: "only-on"])
+/// XCTAssertEqual("second", logger2[metadataKey: "only-on"])
+/// ```
+///
+/// ### Special cases
+///
+/// In certain special cases, the log level behaving like a value on `Logger` might not be what you want. For example,
+/// you might want to set the log level across _all_ `Logger`s to `.debug` when say a signal (eg. `SIGUSR1`) is received
+/// to be able to debug special failures in production. This special case is acceptable but we urge you to create a
+/// solution specific to your `LogHandler` implementation to achieve that. Please find an example implementation of this
+/// behavior below, on reception of the signal you would call
+/// `LogHandlerWithGlobalLogLevelOverride.overrideGlobalLogLevel = .debug`, for example.
+///
+/// ```swift
+/// import class Foundation.NSLock
+///
+/// public struct LogHandlerWithGlobalLogLevelOverride: LogHandler {
+///     // the static properties hold the globally overridden log level (if overridden)
+///     private static let overrideLock = NSLock()
+///     private static var overrideLogLevel: Logger.Level? = nil
+///
+///     // this holds the log level if not overridden
+///     private var _logLevel: Logger.Level = .info
+///
+///     // metadata storage
+///     public var metadata: Logger.Metadata = [:]
+///
+///     public init(label: String) {
+///         // [...]
+///     }
+///
+///     public var logLevel: Logger.Level {
+///         // when we get asked for the log level, we check if it was globally overridden or not
+///         get {
+///             LogHandlerWithGlobalLogLevelOverride.overrideLock.lock()
+///             defer { LogHandlerWithGlobalLogLevelOverride.overrideLock.unlock() }
+///             return LogHandlerWithGlobalLogLevelOverride.overrideLogLevel ?? self._logLevel
+///         }
+///         // we set the log level whenever we're asked (note: this might not have an effect if globally
+///         // overridden)
+///         set {
+///             self._logLevel = newValue
+///         }
+///     }
+///
+///     public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?,
+///                     source: String, file: String, function: String, line: UInt) {
+///         // [...]
+///     }
+///
+///     public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
+///         get {
+///             return self.metadata[metadataKey]
+///         }
+///         set(newValue) {
+///             self.metadata[metadataKey] = newValue
+///         }
+///     }
+///
+///     // this is the function to globally override the log level, it is not part of the `LogHandler` protocol
+///     public static func overrideGlobalLogLevel(_ logLevel: Logger.Level) {
+///         LogHandlerWithGlobalLogLevelOverride.overrideLock.lock()
+///         defer { LogHandlerWithGlobalLogLevelOverride.overrideLock.unlock() }
+///         LogHandlerWithGlobalLogLevelOverride.overrideLogLevel = logLevel
+///     }
+/// }
+/// ```
+///
+/// Please note that the above `LogHandler` will still pass the 'log level is a value' test above it iff the global log
+/// level has not been overridden. And most importantly it passes the requirement listed above: A change to the log
+/// level on one `Logger` should not affect the log level of another `Logger` variable.
+public protocol LogHandler: _SwiftLogSendableLogHandler {
+    /// The metadata provider this `LogHandler` will use when a log statement is about to be emitted.
+    ///
+    /// A ``Logger/MetadataProvider`` may add a constant set of metadata,
+    /// or use task-local values to pick up contextual metadata and add it to emitted logs.
+    var metadataProvider: Logger.MetadataProvider? { get set }
+
+    /// This method is called when a `LogHandler` must emit a log message. There is no need for the `LogHandler` to
+    /// check if the `level` is above or below the configured `logLevel` as `Logger` already performed this check and
+    /// determined that a message should be logged.
+    ///
+    /// - parameters:
+    ///     - level: The log level the message was logged at.
+    ///     - message: The message to log. To obtain a `String` representation call `message.description`.
+    ///     - metadata: The metadata associated to this log message.
+    ///     - source: The source where the log message originated, for example the logging module.
+    ///     - file: The file the log message was emitted from.
+    ///     - function: The function the log line was emitted from.
+    ///     - line: The line the log message was emitted from.
+    func log(level: Logger.Level,
+             message: Logger.Message,
+             metadata: Logger.Metadata?,
+             source: String,
+             file: String,
+             function: String,
+             line: UInt)
+
+    /// SwiftLog 1.0 compatibility method. Please do _not_ implement, implement
+    /// `log(level:message:metadata:source:file:function:line:)` instead.
+    @available(*, deprecated, renamed: "log(level:message:metadata:source:file:function:line:)")
+    func log(level: VitalLogging.Logger.Level, message: VitalLogging.Logger.Message, metadata: VitalLogging.Logger.Metadata?, file: String, function: String, line: UInt)
+
+    /// Add, remove, or change the logging metadata.
+    ///
+    /// - note: `LogHandler`s must treat logging metadata as a value type. This means that the change in metadata must
+    ///         only affect this very `LogHandler`.
+    ///
+    /// - parameters:
+    ///    - metadataKey: The key for the metadata item
+    subscript(metadataKey _: String) -> Logger.Metadata.Value? { get set }
+
+    /// Get or set the entire metadata storage as a dictionary.
+    ///
+    /// - note: `LogHandler`s must treat logging metadata as a value type. This means that the change in metadata must
+    ///         only affect this very `LogHandler`.
+    var metadata: Logger.Metadata { get set }
+
+    /// Get or set the configured log level.
+    ///
+    /// - note: `LogHandler`s must treat the log level as a value type. This means that the change in metadata must
+    ///         only affect this very `LogHandler`. It is acceptable to provide some form of global log level override
+    ///         that means a change in log level on a particular `LogHandler` might not be reflected in any
+    ///        `LogHandler`.
+    var logLevel: Logger.Level { get set }
+}
+
+extension LogHandler {
+    /// Default implementation for `metadataProvider` which defaults to `nil`.
+    /// This default exists in order to facilitate source-compatible introduction of the `metadataProvider` protocol requirement.
+    public var metadataProvider: Logger.MetadataProvider? {
+        get {
+            nil
+        }
+        set {
+            #if DEBUG
+            if LoggingSystem.warnOnceLogHandlerNotSupportedMetadataProvider(Self.self) {
+                self.log(level: .warning, message: "Attempted to set metadataProvider on \(Self.self) that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.", metadata: nil, source: "Logging", file: #file, function: #function, line: #line)
+            }
+            #endif
+        }
+    }
+}
+
+extension LogHandler {
+    @available(*, deprecated, message: "You should implement this method instead of using the default implementation")
+    public func log(level: Logger.Level,
+                    message: Logger.Message,
+                    metadata: Logger.Metadata?,
+                    source: String,
+                    file: String,
+                    function: String,
+                    line: UInt) {
+        self.log(level: level, message: message, metadata: metadata, file: file, function: function, line: line)
+    }
+
+    @available(*, deprecated, renamed: "log(level:message:metadata:source:file:function:line:)")
+    public func log(level: VitalLogging.Logger.Level, message: VitalLogging.Logger.Message, metadata: VitalLogging.Logger.Metadata?, file: String, function: String, line: UInt) {
+        self.log(level: level,
+                 message: message,
+                 metadata: metadata,
+                 source: Logger.currentModule(filePath: file),
+                 file: file,
+                 function: function,
+                 line: line)
+    }
+}
+
+// MARK: - Sendable support helpers
+
+#if compiler(>=5.6)
+@preconcurrency public protocol _SwiftLogSendableLogHandler: Sendable {}
+#else
+public protocol _SwiftLogSendableLogHandler {}
+#endif

--- a/Sources/VitalLogging/Logging.swift
+++ b/Sources/VitalLogging/Logging.swift
@@ -1,0 +1,1551 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Logging API open source project
+//
+// Copyright (c) 2018-2019 Apple Inc. and the Swift Logging API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif os(Windows)
+import CRT
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WASILibc)
+import WASILibc
+#else
+#error("Unsupported runtime")
+#endif
+
+/// A `Logger` is the central type in `SwiftLog`. Its central function is to emit log messages using one of the methods
+/// corresponding to a log level.
+///
+/// `Logger`s are value types with respect to the ``logLevel`` and the ``metadata`` (as well as the immutable `label`
+/// and the selected ``LogHandler``). Therefore, `Logger`s are suitable to be passed around between libraries if you want
+/// to preserve metadata across libraries.
+///
+/// The most basic usage of a `Logger` is
+///
+/// ```swift
+/// logger.info("Hello World!")
+/// ```
+public struct Logger {
+    @usableFromInline
+    var handler: LogHandler
+
+    /// An identifier of the creator of this `Logger`.
+    public let label: String
+
+    /// The metadata provider this logger was created with.
+    public var metadataProvider: Logger.MetadataProvider? {
+        return self.handler.metadataProvider
+    }
+
+    internal init(label: String, _ handler: LogHandler) {
+        self.label = label
+        self.handler = handler
+    }
+}
+
+extension Logger {
+    #if compiler(>=5.3)
+    /// Log a message passing the log level as a parameter.
+    ///
+    /// If the `logLevel` passed to this method is more severe than the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - level: The log level to log `message` at. For the available log levels, see `Logger.Level`.
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    @inlinable
+    public func log(level: Logger.Level,
+                    _ message: @autoclosure () -> Logger.Message,
+                    metadata: @autoclosure () -> Logger.Metadata? = nil,
+                    source: @autoclosure () -> String? = nil,
+                    file: String = #fileID, function: String = #function, line: UInt = #line) {
+        if self.logLevel <= level {
+            self.handler.log(level: level,
+                             message: message(),
+                             metadata: metadata(),
+                             source: source() ?? Logger.currentModule(fileID: (file)),
+                             file: file, function: function, line: line)
+        }
+    }
+
+    #else
+    @inlinable
+    public func log(level: Logger.Level,
+                    _ message: @autoclosure () -> Logger.Message,
+                    metadata: @autoclosure () -> Logger.Metadata? = nil,
+                    source: @autoclosure () -> String? = nil,
+                    file: String = #file, function: String = #function, line: UInt = #line) {
+        if self.logLevel <= level {
+            self.handler.log(level: level,
+                             message: message(),
+                             metadata: metadata(),
+                             source: source() ?? Logger.currentModule(filePath: (file)),
+                             file: file, function: function, line: line)
+        }
+    }
+    #endif
+
+    /// Log a message passing the log level as a parameter.
+    ///
+    /// If the ``logLevel`` passed to this method is more severe than the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - level: The log level to log `message` at. For the available log levels, see `Logger.Level`.
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func log(level: Logger.Level,
+                    _ message: @autoclosure () -> Logger.Message,
+                    metadata: @autoclosure () -> Logger.Metadata? = nil,
+                    file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: level, message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func log(level: Logger.Level,
+                    _ message: @autoclosure () -> Logger.Message,
+                    metadata: @autoclosure () -> Logger.Metadata? = nil,
+                    file: String = #file, function: String = #function, line: UInt = #line) {
+        self.log(level: level, message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Add, change, or remove a logging metadata item.
+    ///
+    /// - note: Logging metadata behaves as a value that means a change to the logging metadata will only affect the
+    ///         very `Logger` it was changed on.
+    @inlinable
+    public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
+        get {
+            return self.handler[metadataKey: metadataKey]
+        }
+        set {
+            self.handler[metadataKey: metadataKey] = newValue
+        }
+    }
+
+    /// Get or set the log level configured for this `Logger`.
+    ///
+    /// - note: `Logger`s treat `logLevel` as a value. This means that a change in `logLevel` will only affect this
+    ///         very `Logger`. It is acceptable for logging backends to have some form of global log level override
+    ///         that affects multiple or even all loggers. This means a change in `logLevel` to one `Logger` might in
+    ///         certain cases have no effect.
+    @inlinable
+    public var logLevel: Logger.Level {
+        get {
+            return self.handler.logLevel
+        }
+        set {
+            self.handler.logLevel = newValue
+        }
+    }
+}
+
+extension Logger {
+    /// Log a message passing with the ``Logger/Level/trace`` log level.
+    ///
+    /// If `.trace` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func trace(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      source: @autoclosure () -> String? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .trace, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func trace(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      source: @autoclosure () -> String? = nil,
+                      file: String = #file, function: String = #function, line: UInt = #line) {
+        self.log(level: .trace, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/trace`` log level.
+    ///
+    /// If `.trace` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func trace(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.trace(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func trace(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      file: String = #file, function: String = #function, line: UInt = #line) {
+        self.trace(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/debug`` log level.
+    ///
+    /// If `.debug` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func debug(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      source: @autoclosure () -> String? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .debug, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func debug(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      source: @autoclosure () -> String? = nil,
+                      file: String = #file, function: String = #function, line: UInt = #line) {
+        self.log(level: .debug, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/debug`` log level.
+    ///
+    /// If `.debug` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func debug(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.debug(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func debug(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      file: String = #file, function: String = #function, line: UInt = #line) {
+        self.debug(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/info`` log level.
+    ///
+    /// If `.info` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func info(_ message: @autoclosure () -> Logger.Message,
+                     metadata: @autoclosure () -> Logger.Metadata? = nil,
+                     source: @autoclosure () -> String? = nil,
+                     file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .info, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func info(_ message: @autoclosure () -> Logger.Message,
+                     metadata: @autoclosure () -> Logger.Metadata? = nil,
+                     source: @autoclosure () -> String? = nil,
+                     file: String = #file, function: String = #function, line: UInt = #line) {
+        self.log(level: .info, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/info`` log level.
+    ///
+    /// If `.info` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func info(_ message: @autoclosure () -> Logger.Message,
+                     metadata: @autoclosure () -> Logger.Metadata? = nil,
+                     file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.info(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func info(_ message: @autoclosure () -> Logger.Message,
+                     metadata: @autoclosure () -> Logger.Metadata? = nil,
+                     file: String = #file, function: String = #function, line: UInt = #line) {
+        self.info(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/notice`` log level.
+    ///
+    /// If `.notice` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func notice(_ message: @autoclosure () -> Logger.Message,
+                       metadata: @autoclosure () -> Logger.Metadata? = nil,
+                       source: @autoclosure () -> String? = nil,
+                       file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .notice, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func notice(_ message: @autoclosure () -> Logger.Message,
+                       metadata: @autoclosure () -> Logger.Metadata? = nil,
+                       source: @autoclosure () -> String? = nil,
+                       file: String = #file, function: String = #function, line: UInt = #line) {
+        self.log(level: .notice, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/notice`` log level.
+    ///
+    /// If `.notice` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func notice(_ message: @autoclosure () -> Logger.Message,
+                       metadata: @autoclosure () -> Logger.Metadata? = nil,
+                       file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.notice(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func notice(_ message: @autoclosure () -> Logger.Message,
+                       metadata: @autoclosure () -> Logger.Metadata? = nil,
+                       file: String = #file, function: String = #function, line: UInt = #line) {
+        self.notice(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/warning`` log level.
+    ///
+    /// If `.warning` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func warning(_ message: @autoclosure () -> Logger.Message,
+                        metadata: @autoclosure () -> Logger.Metadata? = nil,
+                        source: @autoclosure () -> String? = nil,
+                        file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .warning, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func warning(_ message: @autoclosure () -> Logger.Message,
+                        metadata: @autoclosure () -> Logger.Metadata? = nil,
+                        source: @autoclosure () -> String? = nil,
+                        file: String = #file, function: String = #function, line: UInt = #line) {
+        self.log(level: .warning, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/warning`` log level.
+    ///
+    /// If `.warning` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func warning(_ message: @autoclosure () -> Logger.Message,
+                        metadata: @autoclosure () -> Logger.Metadata? = nil,
+                        file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.warning(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func warning(_ message: @autoclosure () -> Logger.Message,
+                        metadata: @autoclosure () -> Logger.Metadata? = nil,
+                        file: String = #file, function: String = #function, line: UInt = #line) {
+        self.warning(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/error`` log level.
+    ///
+    /// If `.error` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func error(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      source: @autoclosure () -> String? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .error, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func error(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      source: @autoclosure () -> String? = nil,
+                      file: String = #file, function: String = #function, line: UInt = #line) {
+        self.log(level: .error, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/error`` log level.
+    ///
+    /// If `.error` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func error(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.error(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func error(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      file: String = #file, function: String = #function, line: UInt = #line) {
+        self.error(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/critical`` log level.
+    ///
+    /// `.critical` messages will always be logged.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func critical(_ message: @autoclosure () -> Logger.Message,
+                         metadata: @autoclosure () -> Logger.Metadata? = nil,
+                         source: @autoclosure () -> String? = nil,
+                         file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .critical, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func critical(_ message: @autoclosure () -> Logger.Message,
+                         metadata: @autoclosure () -> Logger.Metadata? = nil,
+                         source: @autoclosure () -> String? = nil,
+                         file: String = #file, function: String = #function, line: UInt = #line) {
+        self.log(level: .critical, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+    #endif
+
+    /// Log a message passing with the ``Logger/Level/critical`` log level.
+    ///
+    /// `.critical` messages will always be logged.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func critical(_ message: @autoclosure () -> Logger.Message,
+                         metadata: @autoclosure () -> Logger.Metadata? = nil,
+                         file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.critical(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
+    @inlinable
+    public func critical(_ message: @autoclosure () -> Logger.Message,
+                         metadata: @autoclosure () -> Logger.Metadata? = nil,
+                         file: String = #file, function: String = #function, line: UInt = #line) {
+        self.critical(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+    #endif
+}
+
+/// The `LoggingSystem` is a global facility where the default logging backend implementation (`LogHandler`) can be
+/// configured. `LoggingSystem` is set up just once in a given program to set up the desired logging backend
+/// implementation.
+public enum LoggingSystem {
+    private static let _factory = FactoryBox { label, _ in StreamLogHandler.standardOutput(label: label) }
+    private static let _metadataProviderFactory = MetadataProviderBox(nil)
+
+    #if DEBUG
+    private static var _warnOnceBox: WarnOnceBox = WarnOnceBox()
+    #endif
+
+    /// `bootstrap` is a one-time configuration function which globally selects the desired logging backend
+    /// implementation. `bootstrap` can be called at maximum once in any given program, calling it more than once will
+    /// lead to undefined behavior, most likely a crash.
+    ///
+    /// - parameters:
+    ///     - factory: A closure that given a `Logger` identifier, produces an instance of the `LogHandler`.
+    public static func bootstrap(_ factory: @escaping (String) -> LogHandler) {
+        self._factory.replaceFactory({ label, _ in
+            factory(label)
+        }, validate: true)
+    }
+
+    /// `bootstrap` is a one-time configuration function which globally selects the desired logging backend
+    /// implementation.
+    ///
+    /// - Warning:
+    /// `bootstrap` can be called at maximum once in any given program, calling it more than once will
+    /// lead to undefined behavior, most likely a crash.
+    ///
+    /// - parameters:
+    ///     - metadataProvider: The `MetadataProvider` used to inject runtime-generated metadata from the execution context.
+    ///     - factory: A closure that given a `Logger` identifier, produces an instance of the `LogHandler`.
+    public static func bootstrap(_ factory: @escaping (String, Logger.MetadataProvider?) -> LogHandler,
+                                 metadataProvider: Logger.MetadataProvider?) {
+        self._metadataProviderFactory.replaceMetadataProvider(metadataProvider, validate: true)
+        self._factory.replaceFactory(factory, validate: true)
+    }
+
+    // for our testing we want to allow multiple bootstrapping
+    internal static func bootstrapInternal(_ factory: @escaping (String) -> LogHandler) {
+        self._metadataProviderFactory.replaceMetadataProvider(nil, validate: false)
+        self._factory.replaceFactory({ label, _ in
+            factory(label)
+        }, validate: false)
+    }
+
+    // for our testing we want to allow multiple bootstrapping
+    internal static func bootstrapInternal(_ factory: @escaping (String, Logger.MetadataProvider?) -> LogHandler,
+                                           metadataProvider: Logger.MetadataProvider?) {
+        self._metadataProviderFactory.replaceMetadataProvider(metadataProvider, validate: false)
+        self._factory.replaceFactory(factory, validate: false)
+    }
+
+    fileprivate static var factory: (String, Logger.MetadataProvider?) -> LogHandler {
+        return { label, metadataProvider in
+            self._factory.underlying(label, metadataProvider)
+        }
+    }
+
+    /// System wide ``Logger/MetadataProvider`` that was configured during the logging system's `bootstrap`.
+    ///
+    /// When creating a ``Logger`` using the plain ``Logger/init(label:)`` initializer, this metadata provider
+    /// will be provided to it.
+    ///
+    /// When using custom log handler factories, make sure to provide the bootstrapped metadata provider to them,
+    /// or the metadata will not be filled in automatically using the provider on log-sites. While using a custom
+    /// factory to avoid using the bootstrapped metadata provider may sometimes be useful, usually it will lead to
+    /// un-expected behavior, so make sure to always propagate it to your handlers.
+    public static var metadataProvider: Logger.MetadataProvider? {
+        return self._metadataProviderFactory.metadataProvider
+    }
+
+    #if DEBUG
+    /// Used to warn only once about a specific ``LogHandler`` type when it does not support ``Logger/MetadataProvider``,
+    /// but an attempt was made to set a metadata provider on such handler. In order to avoid flooding the system with
+    /// warnings such warning is only emitted in debug mode, and even then at-most once for a handler type.
+    internal static func warnOnceLogHandlerNotSupportedMetadataProvider<Handler: LogHandler>(_ type: Handler.Type) -> Bool {
+        self._warnOnceBox.warnOnceLogHandlerNotSupportedMetadataProvider(type: type)
+    }
+    #endif
+
+    private final class FactoryBox {
+        private let lock = ReadWriteLock()
+        fileprivate var _underlying: (_ label: String, _ provider: Logger.MetadataProvider?) -> LogHandler
+        private var initialized = false
+
+        init(_ underlying: @escaping (String, Logger.MetadataProvider?) -> LogHandler) {
+            self._underlying = underlying
+        }
+
+        func replaceFactory(_ factory: @escaping (String, Logger.MetadataProvider?) -> LogHandler, validate: Bool) {
+            self.lock.withWriterLock {
+                precondition(!validate || !self.initialized, "logging system can only be initialized once per process.")
+                self._underlying = factory
+                self.initialized = true
+            }
+        }
+
+        var underlying: (String, Logger.MetadataProvider?) -> LogHandler {
+            return self.lock.withReaderLock {
+                return self._underlying
+            }
+        }
+    }
+
+    private final class MetadataProviderBox {
+        private let lock = ReadWriteLock()
+
+        internal var _underlying: Logger.MetadataProvider?
+        private var initialized = false
+
+        init(_ underlying: Logger.MetadataProvider?) {
+            self._underlying = underlying
+        }
+
+        func replaceMetadataProvider(_ metadataProvider: Logger.MetadataProvider?, validate: Bool) {
+            self.lock.withWriterLock {
+                precondition(!validate || !self.initialized, "logging system can only be initialized once per process.")
+                self._underlying = metadataProvider
+                self.initialized = true
+            }
+        }
+
+        var metadataProvider: Logger.MetadataProvider? {
+            return self.lock.withReaderLock {
+                return self._underlying
+            }
+        }
+    }
+}
+
+extension Logger {
+    /// `Metadata` is a typealias for `[String: Logger.MetadataValue]` the type of the metadata storage.
+    public typealias Metadata = [String: MetadataValue]
+
+    /// A logging metadata value. `Logger.MetadataValue` is string, array, and dictionary literal convertible.
+    ///
+    /// `MetadataValue` provides convenient conformances to `ExpressibleByStringInterpolation`,
+    /// `ExpressibleByStringLiteral`, `ExpressibleByArrayLiteral`, and `ExpressibleByDictionaryLiteral` which means
+    /// that when constructing `MetadataValue`s you should default to using Swift's usual literals.
+    ///
+    /// Examples:
+    ///  - prefer `logger.info("user logged in", metadata: ["user-id": "\(user.id)"])` over
+    ///    `..., metadata: ["user-id": .string(user.id.description)])`
+    ///  - prefer `logger.info("user selected colors", metadata: ["colors": ["\(user.topColor)", "\(user.secondColor)"]])`
+    ///    over `..., metadata: ["colors": .array([.string("\(user.topColor)"), .string("\(user.secondColor)")])`
+    ///  - prefer `logger.info("nested info", metadata: ["nested": ["fave-numbers": ["\(1)", "\(2)", "\(3)"], "foo": "bar"]])`
+    ///    over `..., metadata: ["nested": .dictionary(["fave-numbers": ...])])`
+    public enum MetadataValue {
+        /// A metadata value which is a `String`.
+        ///
+        /// Because `MetadataValue` implements `ExpressibleByStringInterpolation`, and `ExpressibleByStringLiteral`,
+        /// you don't need to type `.string(someType.description)` you can use the string interpolation `"\(someType)"`.
+        case string(String)
+
+        /// A metadata value which is some `CustomStringConvertible`.
+        #if compiler(>=5.7)
+        case stringConvertible(CustomStringConvertible & Sendable)
+        #else
+        case stringConvertible(CustomStringConvertible)
+        #endif
+        /// A metadata value which is a dictionary from `String` to `Logger.MetadataValue`.
+        ///
+        /// Because `MetadataValue` implements `ExpressibleByDictionaryLiteral`, you don't need to type
+        /// `.dictionary(["foo": .string("bar \(buz)")])`, you can just use the more natural `["foo": "bar \(buz)"]`.
+        case dictionary(Metadata)
+
+        /// A metadata value which is an array of `Logger.MetadataValue`s.
+        ///
+        /// Because `MetadataValue` implements `ExpressibleByArrayLiteral`, you don't need to type
+        /// `.array([.string("foo"), .string("bar \(buz)")])`, you can just use the more natural `["foo", "bar \(buz)"]`.
+        case array([Metadata.Value])
+    }
+
+    /// The log level.
+    ///
+    /// Log levels are ordered by their severity, with `.trace` being the least severe and
+    /// `.critical` being the most severe.
+    public enum Level: String, Codable, CaseIterable {
+        /// Appropriate for messages that contain information normally of use only when
+        /// tracing the execution of a program.
+        case trace
+
+        /// Appropriate for messages that contain information normally of use only when
+        /// debugging a program.
+        case debug
+
+        /// Appropriate for informational messages.
+        case info
+
+        /// Appropriate for conditions that are not error conditions, but that may require
+        /// special handling.
+        case notice
+
+        /// Appropriate for messages that are not error conditions, but more severe than
+        /// `.notice`.
+        case warning
+
+        /// Appropriate for error conditions.
+        case error
+
+        /// Appropriate for critical error conditions that usually require immediate
+        /// attention.
+        ///
+        /// When a `critical` message is logged, the logging backend (`LogHandler`) is free to perform
+        /// more heavy-weight operations to capture system state (such as capturing stack traces) to facilitate
+        /// debugging.
+        case critical
+    }
+
+    /// Construct a `Logger` given a `label` identifying the creator of the `Logger`.
+    ///
+    /// The `label` should identify the creator of the `Logger`. This can be an application, a sub-system, or even
+    /// a datatype.
+    ///
+    /// - parameters:
+    ///     - label: An identifier for the creator of a `Logger`.
+    public init(label: String) {
+        self.init(label: label, LoggingSystem.factory(label, LoggingSystem.metadataProvider))
+    }
+
+    /// Construct a `Logger` given a `label` identifying the creator of the `Logger` or a non-standard `LogHandler`.
+    ///
+    /// The `label` should identify the creator of the `Logger`. This can be an application, a sub-system, or even
+    /// a datatype.
+    ///
+    /// This initializer provides an escape hatch in case the global default logging backend implementation (set up
+    /// using `LoggingSystem.bootstrap` is not appropriate for this particular logger.
+    ///
+    /// - parameters:
+    ///     - label: An identifier for the creator of a `Logger`.
+    ///     - factory: A closure creating non-standard `LogHandler`s.
+    public init(label: String, factory: (String) -> LogHandler) {
+        self = Logger(label: label, factory(label))
+    }
+
+    /// Construct a `Logger` given a `label` identifying the creator of the `Logger` or a non-standard `LogHandler`.
+    ///
+    /// The `label` should identify the creator of the `Logger`. This can be an application, a sub-system, or even
+    /// a datatype.
+    ///
+    /// This initializer provides an escape hatch in case the global default logging backend implementation (set up
+    /// using `LoggingSystem.bootstrap` is not appropriate for this particular logger.
+    ///
+    /// - parameters:
+    ///     - label: An identifier for the creator of a `Logger`.
+    ///     - factory: A closure creating non-standard `LogHandler`s.
+    public init(label: String, factory: (String, Logger.MetadataProvider?) -> LogHandler) {
+        self = Logger(label: label, factory(label, LoggingSystem.metadataProvider))
+    }
+
+    /// Construct a `Logger` given a `label` identifying the creator of the `Logger` and a non-standard ``Logger/MetadataProvider``.
+    ///
+    /// The `label` should identify the creator of the `Logger`. This can be an application, a sub-system, or even
+    /// a datatype.
+    ///
+    /// This initializer provides an escape hatch in case the global default logging backend implementation (set up
+    /// using `LoggingSystem.bootstrap` is not appropriate for this particular logger.
+    ///
+    /// - parameters:
+    ///     - label: An identifier for the creator of a `Logger`.
+    ///     - metadataProvider: The custom metadata provider this logger should invoke,
+    ///                         instead of the system wide bootstrapped one, when a log statement is about to be emitted.
+    public init(label: String, metadataProvider: MetadataProvider) {
+        self = Logger(label: label, factory: { label in
+            var handler = LoggingSystem.factory(label, metadataProvider)
+            handler.metadataProvider = metadataProvider
+            return handler
+        })
+    }
+}
+
+extension Logger.Level {
+    internal var naturalIntegralValue: Int {
+        switch self {
+        case .trace:
+            return 0
+        case .debug:
+            return 1
+        case .info:
+            return 2
+        case .notice:
+            return 3
+        case .warning:
+            return 4
+        case .error:
+            return 5
+        case .critical:
+            return 6
+        }
+    }
+}
+
+extension Logger.Level: Comparable {
+    public static func < (lhs: Logger.Level, rhs: Logger.Level) -> Bool {
+        return lhs.naturalIntegralValue < rhs.naturalIntegralValue
+    }
+}
+
+// Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
+// https://bugs.swift.org/browse/SR-9687
+// Then we could write it as follows and it would work under Swift 5 and not only 4 as it does currently:
+// extension Logger.Metadata.Value: Equatable {
+extension Logger.MetadataValue: Equatable {
+    public static func == (lhs: Logger.Metadata.Value, rhs: Logger.Metadata.Value) -> Bool {
+        switch (lhs, rhs) {
+        case (.string(let lhs), .string(let rhs)):
+            return lhs == rhs
+        case (.stringConvertible(let lhs), .stringConvertible(let rhs)):
+            return lhs.description == rhs.description
+        case (.array(let lhs), .array(let rhs)):
+            return lhs == rhs
+        case (.dictionary(let lhs), .dictionary(let rhs)):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}
+
+extension Logger {
+    /// `Logger.Message` represents a log message's text. It is usually created using string literals.
+    ///
+    /// Example creating a `Logger.Message`:
+    ///
+    ///     let world: String = "world"
+    ///     let myLogMessage: Logger.Message = "Hello \(world)"
+    ///
+    /// Most commonly, `Logger.Message`s appear simply as the parameter to a logging method such as:
+    ///
+    ///     logger.info("Hello \(world)")
+    ///
+    public struct Message: ExpressibleByStringLiteral, Equatable, CustomStringConvertible, ExpressibleByStringInterpolation {
+        public typealias StringLiteralType = String
+
+        private var value: String
+
+        public init(stringLiteral value: String) {
+            self.value = value
+        }
+
+        public var description: String {
+            return self.value
+        }
+    }
+}
+
+/// A pseudo-`LogHandler` that can be used to send messages to multiple other `LogHandler`s.
+///
+/// ### Effective Logger.Level
+///
+/// When first initialized the multiplex log handlers' log level is automatically set to the minimum of all the
+/// passed in log handlers. This ensures that each of the handlers will be able to log at their appropriate level
+/// any log events they might be interested in.
+///
+/// Example:
+/// If log handler `A` is logging at `.debug` level, and log handler `B` is logging at `.info` level, the constructed
+/// `MultiplexLogHandler([A, B])`'s effective log level will be set to `.debug`, meaning that debug messages will be
+/// handled by this handler, while only logged by the underlying `A` log handler (since `B`'s log level is `.info`
+/// and thus it would not actually log that log message).
+///
+/// If the log level is _set_ on a `Logger` backed by an `MultiplexLogHandler` the log level will apply to *all*
+/// underlying log handlers, allowing a logger to still select at what level it wants to log regardless of if the underlying
+/// handler is a multiplex or a normal one. If for some reason one might want to not allow changing a log level of a specific
+/// handler passed into the multiplex log handler, this is possible by wrapping it in a handler which ignores any log level changes.
+///
+/// ### Effective Logger.Metadata
+///
+/// Since a `MultiplexLogHandler` is a combination of multiple log handlers, the handling of metadata can be non-obvious.
+/// For example, the underlying log handlers may have metadata of their own set before they are used to initialize the multiplex log handler.
+///
+/// The multiplex log handler acts purely as proxy and does not make any changes to underlying handler metadata other than
+/// proxying writes that users made on a `Logger` instance backed by this handler.
+///
+/// Setting metadata is always proxied through to _all_ underlying handlers, meaning that if a modification like
+/// `logger[metadataKey: "x"] = "y"` is made, all underlying log handlers that this multiplex handler was initiated with
+/// will observe this change.
+///
+/// Reading metadata from the multiplex log handler MAY need to pick one of conflicting values if the underlying log handlers
+/// were already initiated with some metadata before passing them into the multiplex handler. The multiplex handler uses
+/// the order in which the handlers were passed in during its initialization as a priority indicator - the first handler's
+/// values are more important than the next handlers values, etc.
+///
+/// Example:
+/// If the multiplex log handler was initiated with two handlers like this: `MultiplexLogHandler([handler1, handler2])`.
+/// The handlers each have some already set metadata: `handler1` has metadata values for keys `one` and `all`, and `handler2`
+/// has values for keys `two` and `all`.
+///
+/// A query through the multiplex log handler the key `one` naturally returns `handler1`'s value, and a query for `two`
+/// naturally returns `handler2`'s value. Querying for the key `all` will return `handler1`'s value, as that handler was indicated
+/// "more important" than the second handler. The same rule applies when querying for the `metadata` property of the
+/// multiplex log handler - it constructs `Metadata` uniquing values.
+public struct MultiplexLogHandler: LogHandler {
+    private var handlers: [LogHandler]
+    private var effectiveLogLevel: Logger.Level
+    /// This metadata provider runs after all metadata providers of the multiplexed handlers.
+    private var _metadataProvider: Logger.MetadataProvider?
+
+    /// Create a `MultiplexLogHandler`.
+    ///
+    /// - parameters:
+    ///    - handlers: An array of `LogHandler`s, each of which will receive the log messages sent to this `Logger`.
+    ///                The array must not be empty.
+    public init(_ handlers: [LogHandler]) {
+        assert(!handlers.isEmpty, "MultiplexLogHandler.handlers MUST NOT be empty")
+        self.handlers = handlers
+        self.effectiveLogLevel = handlers.map { $0.logLevel }.min() ?? .trace
+    }
+
+    public init(_ handlers: [LogHandler], metadataProvider: Logger.MetadataProvider?) {
+        assert(!handlers.isEmpty, "MultiplexLogHandler.handlers MUST NOT be empty")
+        self.handlers = handlers
+        self.effectiveLogLevel = handlers.map { $0.logLevel }.min() ?? .trace
+        self._metadataProvider = metadataProvider
+    }
+
+    public var logLevel: Logger.Level {
+        get {
+            return self.effectiveLogLevel
+        }
+        set {
+            self.mutatingForEachHandler { $0.logLevel = newValue }
+            self.effectiveLogLevel = newValue
+        }
+    }
+
+    public var metadataProvider: Logger.MetadataProvider? {
+        get {
+            if self.handlers.count == 1 {
+                if let innerHandler = self.handlers.first?.metadataProvider {
+                    if let multiplexHandlerProvider = self._metadataProvider {
+                        return .multiplex([innerHandler, multiplexHandlerProvider])
+                    } else {
+                        return innerHandler
+                    }
+                } else if let multiplexHandlerProvider = self._metadataProvider {
+                    return multiplexHandlerProvider
+                } else {
+                    return nil
+                }
+            } else {
+                var providers: [Logger.MetadataProvider] = []
+                let additionalMetadataProviderCount = (self._metadataProvider != nil ? 1 : 0)
+                providers.reserveCapacity(self.handlers.count + additionalMetadataProviderCount)
+                for handler in self.handlers {
+                    if let provider = handler.metadataProvider {
+                        providers.append(provider)
+                    }
+                }
+                if let multiplexHandlerProvider = self._metadataProvider {
+                    providers.append(multiplexHandlerProvider)
+                }
+                guard !providers.isEmpty else {
+                    return nil
+                }
+                return .multiplex(providers)
+            }
+        }
+        set {
+            self.mutatingForEachHandler { $0.metadataProvider = newValue }
+        }
+    }
+
+    public func log(level: Logger.Level,
+                    message: Logger.Message,
+                    metadata: Logger.Metadata?,
+                    source: String,
+                    file: String,
+                    function: String,
+                    line: UInt) {
+        for handler in self.handlers where handler.logLevel <= level {
+            handler.log(level: level, message: message, metadata: metadata, source: source, file: file, function: function, line: line)
+        }
+    }
+
+    public var metadata: Logger.Metadata {
+        get {
+            var effective: Logger.Metadata = [:]
+            // as a rough estimate we assume that the underlying handlers have a similar metadata count,
+            // and we use the first one's current count to estimate how big of a dictionary we need to allocate:
+            effective.reserveCapacity(self.handlers.first!.metadata.count) // !-safe, we always have at least one handler
+
+            for handler in self.handlers {
+                effective.merge(handler.metadata, uniquingKeysWith: { _, handlerMetadata in handlerMetadata })
+                if let provider = handler.metadataProvider {
+                    effective.merge(provider.get(), uniquingKeysWith: { _, provided in provided })
+                }
+            }
+            if let provider = self._metadataProvider {
+                effective.merge(provider.get(), uniquingKeysWith: { _, provided in provided })
+            }
+
+            return effective
+        }
+        set {
+            self.mutatingForEachHandler { $0.metadata = newValue }
+        }
+    }
+
+    public subscript(metadataKey metadataKey: Logger.Metadata.Key) -> Logger.Metadata.Value? {
+        get {
+            for handler in self.handlers {
+                if let value = handler[metadataKey: metadataKey] {
+                    return value
+                }
+            }
+            return nil
+        }
+        set {
+            self.mutatingForEachHandler { $0[metadataKey: metadataKey] = newValue }
+        }
+    }
+
+    private mutating func mutatingForEachHandler(_ mutator: (inout LogHandler) -> Void) {
+        for index in self.handlers.indices {
+            mutator(&self.handlers[index])
+        }
+    }
+}
+
+#if canImport(WASILibc) || os(Android)
+internal typealias CFilePointer = OpaquePointer
+#else
+internal typealias CFilePointer = UnsafeMutablePointer<FILE>
+#endif
+
+/// A wrapper to facilitate `print`-ing to stderr and stdio that
+/// ensures access to the underlying `FILE` is locked to prevent
+/// cross-thread interleaving of output.
+internal struct StdioOutputStream: TextOutputStream {
+    internal let file: CFilePointer
+    internal let flushMode: FlushMode
+
+    internal func write(_ string: String) {
+        self.contiguousUTF8(string).withContiguousStorageIfAvailable { utf8Bytes in
+            #if os(Windows)
+            _lock_file(self.file)
+            #elseif canImport(WASILibc)
+            // no file locking on WASI
+            #else
+            flockfile(self.file)
+            #endif
+            defer {
+                #if os(Windows)
+                _unlock_file(self.file)
+                #elseif canImport(WASILibc)
+                // no file locking on WASI
+                #else
+                funlockfile(self.file)
+                #endif
+            }
+            _ = fwrite(utf8Bytes.baseAddress!, 1, utf8Bytes.count, self.file)
+            if case .always = self.flushMode {
+                self.flush()
+            }
+        }!
+    }
+
+    /// Flush the underlying stream.
+    /// This has no effect when using the `.always` flush mode, which is the default
+    internal func flush() {
+        _ = fflush(self.file)
+    }
+
+    internal func contiguousUTF8(_ string: String) -> String.UTF8View {
+        var contiguousString = string
+        #if compiler(>=5.1)
+        contiguousString.makeContiguousUTF8()
+        #else
+        contiguousString = string + ""
+        #endif
+        return contiguousString.utf8
+    }
+
+    internal static let stderr = StdioOutputStream(file: systemStderr, flushMode: .always)
+    internal static let stdout = StdioOutputStream(file: systemStdout, flushMode: .always)
+
+    /// Defines the flushing strategy for the underlying stream.
+    internal enum FlushMode {
+        case undefined
+        case always
+    }
+}
+
+// Prevent name clashes
+#if canImport(Darwin)
+let systemStderr = Darwin.stderr
+let systemStdout = Darwin.stdout
+#elseif os(Windows)
+let systemStderr = CRT.stderr
+let systemStdout = CRT.stdout
+#elseif canImport(Glibc)
+let systemStderr = Glibc.stderr!
+let systemStdout = Glibc.stdout!
+#elseif canImport(Musl)
+let systemStderr = Musl.stderr!
+let systemStdout = Musl.stdout!
+#elseif canImport(WASILibc)
+let systemStderr = WASILibc.stderr!
+let systemStdout = WASILibc.stdout!
+#else
+#error("Unsupported runtime")
+#endif
+
+/// `StreamLogHandler` is a simple implementation of `LogHandler` for directing
+/// `Logger` output to either `stderr` or `stdout` via the factory methods.
+///
+/// Metadata is merged in the following order:
+/// 1. Metadata set on the log handler itself is used as the base metadata.
+/// 2. The handler's ``metadataProvider`` is invoked, overriding any existing keys.
+/// 3. The per-log-statement metadata is merged, overriding any previously set keys.
+public struct StreamLogHandler: LogHandler {
+    #if compiler(>=5.6)
+    internal typealias _SendableTextOutputStream = TextOutputStream & Sendable
+    #else
+    internal typealias _SendableTextOutputStream = TextOutputStream
+    #endif
+
+    /// Factory that makes a `StreamLogHandler` to directs its output to `stdout`
+    public static func standardOutput(label: String) -> StreamLogHandler {
+        return StreamLogHandler(label: label, stream: StdioOutputStream.stdout, metadataProvider: LoggingSystem.metadataProvider)
+    }
+
+    /// Factory that makes a `StreamLogHandler` that directs its output to `stdout`
+    public static func standardOutput(label: String, metadataProvider: Logger.MetadataProvider?) -> StreamLogHandler {
+        return StreamLogHandler(label: label, stream: StdioOutputStream.stdout, metadataProvider: metadataProvider)
+    }
+
+    /// Factory that makes a `StreamLogHandler` that directs its output to `stderr`
+    public static func standardError(label: String) -> StreamLogHandler {
+        return StreamLogHandler(label: label, stream: StdioOutputStream.stderr, metadataProvider: LoggingSystem.metadataProvider)
+    }
+
+    /// Factory that makes a `StreamLogHandler` that direct its output to `stderr`
+    public static func standardError(label: String, metadataProvider: Logger.MetadataProvider?) -> StreamLogHandler {
+        return StreamLogHandler(label: label, stream: StdioOutputStream.stderr, metadataProvider: metadataProvider)
+    }
+
+    private let stream: _SendableTextOutputStream
+    private let label: String
+
+    public var logLevel: Logger.Level = .info
+
+    public var metadataProvider: Logger.MetadataProvider?
+
+    private var prettyMetadata: String?
+    public var metadata = Logger.Metadata() {
+        didSet {
+            self.prettyMetadata = self.prettify(self.metadata)
+        }
+    }
+
+    public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
+        get {
+            return self.metadata[metadataKey]
+        }
+        set {
+            self.metadata[metadataKey] = newValue
+        }
+    }
+
+    // internal for testing only
+    internal init(label: String, stream: _SendableTextOutputStream) {
+        self.init(label: label, stream: stream, metadataProvider: LoggingSystem.metadataProvider)
+    }
+
+    // internal for testing only
+    internal init(label: String, stream: _SendableTextOutputStream, metadataProvider: Logger.MetadataProvider?) {
+        self.label = label
+        self.stream = stream
+        self.metadataProvider = metadataProvider
+    }
+
+    public func log(level: Logger.Level,
+                    message: Logger.Message,
+                    metadata explicitMetadata: Logger.Metadata?,
+                    source: String,
+                    file: String,
+                    function: String,
+                    line: UInt) {
+        let effectiveMetadata = StreamLogHandler.prepareMetadata(base: self.metadata, provider: self.metadataProvider, explicit: explicitMetadata)
+
+        let prettyMetadata: String?
+        if let effectiveMetadata = effectiveMetadata {
+            prettyMetadata = self.prettify(effectiveMetadata)
+        } else {
+            prettyMetadata = self.prettyMetadata
+        }
+
+        var stream = self.stream
+        stream.write("\(self.timestamp()) \(level) \(self.label) :\(prettyMetadata.map { " \($0)" } ?? "") [\(source)] \(message)\n")
+    }
+
+    internal static func prepareMetadata(base: Logger.Metadata, provider: Logger.MetadataProvider?, explicit: Logger.Metadata?) -> Logger.Metadata? {
+        var metadata = base
+
+        let provided = provider?.get() ?? [:]
+
+        guard !provided.isEmpty || !((explicit ?? [:]).isEmpty) else {
+            // all per-log-statement values are empty
+            return nil
+        }
+
+        if !provided.isEmpty {
+            metadata.merge(provided, uniquingKeysWith: { _, provided in provided })
+        }
+
+        if let explicit = explicit, !explicit.isEmpty {
+            metadata.merge(explicit, uniquingKeysWith: { _, explicit in explicit })
+        }
+
+        return metadata
+    }
+
+    private func prettify(_ metadata: Logger.Metadata) -> String? {
+        if metadata.isEmpty {
+            return nil
+        } else {
+            return metadata.lazy.sorted(by: { $0.key < $1.key }).map { "\($0)=\($1)" }.joined(separator: " ")
+        }
+    }
+
+    private func timestamp() -> String {
+        var buffer = [Int8](repeating: 0, count: 255)
+        #if os(Windows)
+        var timestamp = __time64_t()
+        _ = _time64(&timestamp)
+
+        var localTime = tm()
+        _ = _localtime64_s(&localTime, &timestamp)
+
+        _ = strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", &localTime)
+        #else
+        var timestamp = time(nil)
+        guard let localTime = localtime(&timestamp) else {
+            return "<unknown>"
+        }
+        strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", localTime)
+        #endif
+        return buffer.withUnsafeBufferPointer {
+            $0.withMemoryRebound(to: CChar.self) {
+                String(cString: $0.baseAddress!)
+            }
+        }
+    }
+}
+
+/// No operation LogHandler, used when no logging is required
+public struct SwiftLogNoOpLogHandler: LogHandler {
+    public init() {}
+
+    public init(_: String) {}
+
+    @inlinable public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {}
+
+    @inlinable public subscript(metadataKey _: String) -> Logger.Metadata.Value? {
+        get {
+            return nil
+        }
+        set {}
+    }
+
+    @inlinable public var metadata: Logger.Metadata {
+        get {
+            return [:]
+        }
+        set {}
+    }
+
+    @inlinable public var logLevel: Logger.Level {
+        get {
+            return .critical
+        }
+        set {}
+    }
+}
+
+extension Logger {
+    @inlinable
+    internal static func currentModule(filePath: String = #file) -> String {
+        let utf8All = filePath.utf8
+        return filePath.utf8.lastIndex(of: UInt8(ascii: "/")).flatMap { lastSlash -> Substring? in
+            utf8All[..<lastSlash].lastIndex(of: UInt8(ascii: "/")).map { secondLastSlash -> Substring in
+                filePath[utf8All.index(after: secondLastSlash) ..< lastSlash]
+            }
+        }.map {
+            String($0)
+        } ?? "n/a"
+    }
+
+    #if compiler(>=5.3)
+    @inlinable
+    internal static func currentModule(fileID: String = #fileID) -> String {
+        let utf8All = fileID.utf8
+        if let slashIndex = utf8All.firstIndex(of: UInt8(ascii: "/")) {
+            return String(fileID[..<slashIndex])
+        } else {
+            return "n/a"
+        }
+    }
+    #endif
+}
+
+// Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
+// https://bugs.swift.org/browse/SR-9686
+extension Logger.MetadataValue: ExpressibleByStringLiteral {
+    public typealias StringLiteralType = String
+
+    public init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+// Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
+// https://bugs.swift.org/browse/SR-9686
+extension Logger.MetadataValue: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .dictionary(let dict):
+            return dict.mapValues { $0.description }.description
+        case .array(let list):
+            return list.map { $0.description }.description
+        case .string(let str):
+            return str
+        case .stringConvertible(let repr):
+            return repr.description
+        }
+    }
+}
+
+// Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
+// https://bugs.swift.org/browse/SR-9687
+extension Logger.MetadataValue: ExpressibleByStringInterpolation {}
+
+// Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
+// https://bugs.swift.org/browse/SR-9686
+extension Logger.MetadataValue: ExpressibleByDictionaryLiteral {
+    public typealias Key = String
+    public typealias Value = Logger.Metadata.Value
+
+    public init(dictionaryLiteral elements: (String, Logger.Metadata.Value)...) {
+        self = .dictionary(.init(uniqueKeysWithValues: elements))
+    }
+}
+
+// Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
+// https://bugs.swift.org/browse/SR-9686
+extension Logger.MetadataValue: ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = Logger.Metadata.Value
+
+    public init(arrayLiteral elements: Logger.Metadata.Value...) {
+        self = .array(elements)
+    }
+}
+
+// MARK: - Debug only warnings
+
+#if DEBUG
+/// Contains state to manage all kinds of "warn only once" warnings which the logging system may want to issue.
+private final class WarnOnceBox {
+    private let lock: Lock = Lock()
+    private var warnOnceLogHandlerNotSupportedMetadataProviderPerType: [ObjectIdentifier: Bool] = [:]
+
+    func warnOnceLogHandlerNotSupportedMetadataProvider<Handler: LogHandler>(type: Handler.Type) -> Bool {
+        self.lock.withLock {
+            let id = ObjectIdentifier(type)
+            if warnOnceLogHandlerNotSupportedMetadataProviderPerType[id] ?? false {
+                return false // don't warn, it was already warned about
+            } else {
+                warnOnceLogHandlerNotSupportedMetadataProviderPerType[id] = true
+                return true // warn about this handler type, it is the first time we encountered it
+            }
+        }
+    }
+}
+#endif
+
+// MARK: - Sendable support helpers
+
+#if compiler(>=5.7.0)
+extension Logger.MetadataValue: Sendable {} // on 5.7 `stringConvertible`'s value marked as Sendable; but if a value not conforming to Sendable is passed there, a warning is emitted. We are okay with warnings, but on 5.6 for the same situation an error is emitted (!)
+#elseif compiler(>=5.6)
+extension Logger.MetadataValue: @unchecked Sendable {} // sadly, On 5.6 a missing Sendable conformance causes an 'error' (specifically this is about `stringConvertible`'s value)
+#endif
+
+#if compiler(>=5.6)
+extension Logger: Sendable {}
+extension Logger.Level: Sendable {}
+extension Logger.Message: Sendable {}
+#endif

--- a/Sources/VitalLogging/MetadataProvider.swift
+++ b/Sources/VitalLogging/MetadataProvider.swift
@@ -1,0 +1,115 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Logging API open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the Swift Logging API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif os(Windows)
+import CRT
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WASILibc)
+import WASILibc
+#else
+#error("Unsupported runtime")
+#endif
+
+#if compiler(>=5.6)
+@preconcurrency protocol _SwiftLogSendable: Sendable {}
+#else
+protocol _SwiftLogSendable {}
+#endif
+
+extension Logger {
+    /// A `MetadataProvider` is used to automatically inject runtime-generated metadata
+    /// to all logs emitted by a logger.
+    ///
+    /// ### Example
+    /// A metadata provider may be used to automatically inject metadata such as
+    /// trace IDs:
+    ///
+    /// ```swift
+    /// import Tracing // https://github.com/apple/swift-distributed-tracing
+    ///
+    /// let metadataProvider = MetadataProvider {
+    ///     guard let traceID = Baggage.current?.traceID else { return nil }
+    ///     return ["traceID": "\(traceID)"]
+    /// }
+    /// let logger = Logger(label: "example", metadataProvider: metadataProvider)
+    /// var baggage = Baggage.topLevel
+    /// baggage.traceID = 42
+    /// Baggage.withValue(baggage) {
+    ///     logger.info("hello") // automatically includes ["traceID": "42"] metadata
+    /// }
+    /// ```
+    ///
+    /// We recommend referring to [swift-distributed-tracing](https://github.com/apple/swift-distributed-tracing)
+    /// for metadata providers which make use of its tracing and metadata propagation infrastructure. It is however
+    /// possible to make use of metadata providers independently of tracing and instruments provided by that library,
+    /// if necessary.
+    public struct MetadataProvider: _SwiftLogSendable {
+        /// Provide ``Logger.Metadata`` from current context.
+        #if swift(>=5.5) && canImport(_Concurrency) // we could instead typealias the function type, but it was requested that we avoid this for better developer experience
+        @usableFromInline
+        internal let _provideMetadata: @Sendable() -> Metadata
+        #else
+        @usableFromInline
+        internal let _provideMetadata: () -> Metadata
+        #endif
+
+        /// Create a new `MetadataProvider`.
+        ///
+        /// - Parameter provideMetadata: A closure extracting metadata from the current execution context.
+        #if swift(>=5.5) && canImport(_Concurrency)
+        public init(_ provideMetadata: @escaping @Sendable() -> Metadata) {
+            self._provideMetadata = provideMetadata
+        }
+
+        #else
+        public init(_ provideMetadata: @escaping () -> Metadata) {
+            self._provideMetadata = provideMetadata
+        }
+        #endif
+
+        /// Invoke the metadata provider and return the generated contextual ``Logger/Metadata``.
+        public func get() -> Metadata {
+            return self._provideMetadata()
+        }
+    }
+}
+
+extension Logger.MetadataProvider {
+    /// A pseudo-`MetadataProvider` that can be used to merge metadata from multiple other `MetadataProvider`s.
+    ///
+    /// ### Merging conflicting keys
+    ///
+    /// `MetadataProvider`s are invoked left to right in the order specified in the `providers` argument.
+    /// In case multiple providers try to add a value for the same key, the last provider "wins" and its value is being used.
+    ///
+    /// - Parameter providers: An array of `MetadataProvider`s to delegate to. The array must not be empty.
+    /// - Returns: A pseudo-`MetadataProvider` merging metadata from the given `MetadataProvider`s.
+    public static func multiplex(_ providers: [Logger.MetadataProvider]) -> Logger.MetadataProvider? {
+        assert(!providers.isEmpty, "providers MUST NOT be empty")
+        return Logger.MetadataProvider {
+            providers.reduce(into: [:]) { metadata, provider in
+                let providedMetadata = provider.get()
+                guard !providedMetadata.isEmpty else {
+                    return
+                }
+                metadata.merge(providedMetadata, uniquingKeysWith: { _, rhs in rhs })
+            }
+        }
+    }
+}

--- a/Sources/VitalLogging/NOTICE.txt
+++ b/Sources/VitalLogging/NOTICE.txt
@@ -1,0 +1,44 @@
+
+                            The SwiftLog Project
+                            ========================
+
+Please visit the SwiftLog web site for more information:
+
+  * https://github.com/apple/swift-log
+
+Copyright 2018, 2019 The SwiftLog Project
+
+The SwiftLog Project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+Also, please refer to each LICENSE.<component>.txt file, which is located in
+the 'license' directory of the distribution file, for the license terms of the
+components that this product depends on.
+
+-------------------------------------------------------------------------------
+
+This product contains a derivation of the Tony Stone's 'process_test_files.rb'.
+
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://codegists.com/snippet/ruby/generate_xctest_linux_runnerrb_tonystone_ruby
+
+---
+
+This product contains a derivation of the lock implementation and various
+scripts from SwiftNIO.
+
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://github.com/apple/swift-nio

--- a/Sources/VitalLogging/README.txt
+++ b/Sources/VitalLogging/README.txt
@@ -1,0 +1,5 @@
+This is a vendored copy of swift-log@1.5.4 in order to support both SPM and CocoaPods.
+The module qualifier `Logging.` is replaced with `VitalLogging.`
+
+Source:  https://github.com/apple/swift-log/tree/1.5.4
+License: Apache License Version 2.0

--- a/Sources/VitalLogging/README.txt
+++ b/Sources/VitalLogging/README.txt
@@ -1,5 +1,11 @@
 This is a vendored copy of swift-log@1.5.4 in order to support both SPM and CocoaPods.
-The module qualifier `Logging.` is replaced with `VitalLogging.`
+
+Modifications:
+
+1. The module qualifier `Logging.` is replaced with `VitalLogging.`.
+2. Only source files under `Sources/Logging/**` are included.
 
 Source:  https://github.com/apple/swift-log/tree/1.5.4
 License: Apache License Version 2.0
+
+This vendored copy also includes the NOTICE.txt and LICENSE.txt from the swift-log project.

--- a/VitalLogging.podspec
+++ b/VitalLogging.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
-    s.name = 'VitalCore'
+    s.name = 'VitalLogging'
     s.version = '0.12.0-beta.2'
-    s.license = 'AGPL v3.0'
-    s.summary = 'The official Swift Library for Vital API, HealthKit and Devices'
+    s.license = 'Apache 2.0'
+    s.summary = 'Logging support for VitalCore'
     s.homepage = 'https://github.com/tryVital/vital-ios'
     s.authors = { 'Vital' => 'contact@tryVital.io' }
     s.source = { :git => 'https://github.com/tryVital/vital-ios.git', :tag => s.version }
@@ -11,10 +11,9 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = '14.0'
     s.swift_versions = ['5']
-    s.source_files = 'Sources/VitalCore/**/*.swift'
+    s.source_files = 'Sources/VitalLogging/*.swift'
 
     s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-
-    s.dependency 'VitalLogging', '~> 0.12.0-beta.2'
 end
+
 


### PR DESCRIPTION
swift-log has no CocoaPods support.
So we have to resort to including a vendored copy to support both SPM and CocoaPods.