### PR TITLE
VIT-6573: Improve anchored query error handling and logging

### DIFF
--- a/Examples/iOS/HealthKit Tab/HealthKitExample.swift
+++ b/Examples/iOS/HealthKit Tab/HealthKitExample.swift
@@ -88,22 +88,21 @@ struct HealthKitExample: View {
     Text(text)
     Spacer()
     
-    if resources.allSatisfy({ permissions.wrappedValue[$0] == true }) {
-      Button("Permission requested") {}
-        .disabled(true)
-        .buttonStyle(PermissionStyle())
-    } else {
-      Button("Request Permission") {
-        Task { @MainActor in
-          await VitalHealthKitClient.shared.ask(readPermissions: resources, writePermissions: writeResources)
 
-          for resource in resources {
-            permissions.wrappedValue[resource] = true
-          }
+    Button(
+      resources.allSatisfy({ permissions.wrappedValue[$0] == true })
+        ? "Permission requested"
+        : "Request permission"
+    ) {
+      Task { @MainActor in
+        await VitalHealthKitClient.shared.ask(readPermissions: resources, writePermissions: writeResources)
+
+        for resource in resources {
+          permissions.wrappedValue[resource] = true
         }
       }
-      .buttonStyle(PermissionStyle())
     }
+    .buttonStyle(PermissionStyle())
   }
 }
 

--- a/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
@@ -392,6 +392,22 @@ extension HKSampleType {
       return nil
     }
   }
+
+  var shortenedIdentifier: String {
+    if self is HKQuantityType {
+      return String(self.identifier.dropFirst("HKQuantityTypeIdentifier".count))
+    }
+
+    if self is HKCorrelationType {
+      return String(self.identifier.dropFirst("HKCorrelationTypeIdentifier".count))
+    }
+
+    if self is HKCategoryType {
+      return String(self.identifier.dropFirst("HKCategoryTypeIdentifier".count))
+    }
+
+    return self.identifier
+  }
 }
 
 func quantity(for statistics: HKStatistics, with options: HKStatisticsOptions?, type: HKQuantityType) -> HKQuantity? {


### PR DESCRIPTION
Handle `.errorAuthorizationNotDetermined`, `.errorAuthorizationDenied`, and `.errorNoData` from HKAnchoredObjectQuery gracefully.

Treat them as "no data" rather than letting the error propagate out and failing the whole sync attempt.

---

This might be a plausible contributor of SDK sync issues, since our activity sync process could be disrupted by this issue, if VO2 Max read permission was not granted.