### PR TITLE
VIT-6595: Fix a hasAskForPermission(_:) false positive

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -135,15 +135,12 @@ extension VitalHealthKitStore {
     } requestReadWriteAuthorization: { readResources, writeResources in
       let readTypes: [HKObjectType] = readResources
         .map(toHealthKitTypes)
-        .flatMap { requirements in
-          requirements.required + requirements.optional
-        }
+        .flatMap(\.allObjectTypes)
+
       let writeTypes: [HKSampleType] = writeResources
         .map(\.toResource)
         .map(toHealthKitTypes)
-        .flatMap { requirements in
-          requirements.required + requirements.optional
-        }
+        .flatMap(\.allObjectTypes)
         .compactMap { $0 as? HKSampleType }
 
       if #available(iOS 15.0, *) {

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient+Logs.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient+Logs.swift
@@ -153,7 +153,7 @@ extension VitalHealthKitClient {
       for resource in VitalResource.all {
         group.addTask {
           let requirements = toHealthKitTypes(resource: resource)
-          let allHealthKitTypes = requirements.required + requirements.optional
+          let allHealthKitTypes = requirements.allObjectTypes
 
           return try await withThrowingTaskGroup(of: (HKObjectType, HKAuthorizationRequestStatus, HKAuthorizationStatus).self) { innerGroup in
             for objectType in allHealthKitTypes {

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -235,7 +235,7 @@ extension VitalHealthKitClient {
     let allowedSampleTypes = Set(
       resources.lazy.map(\.wrapped)
         .map(toHealthKitTypes(resource:))
-        .flatMap { $0.required + $0.optional }
+        .flatMap(\.allObjectTypes)
     )
 
     let set: [Set<HKObjectType>] = observedSampleTypes().map(Set.init)
@@ -661,7 +661,7 @@ extension VitalHealthKitClient {
     }
     
     let requirements = toHealthKitTypes(resource: resource)
-    let dates: [Date] = (requirements.required + requirements.optional).map {
+    let dates: [Date] = requirements.allObjectTypes.map {
       String(describing: $0.self)
     }.compactMap { key in
       storage.read(key: key)?.date


### PR DESCRIPTION
#120 refactored the VitalResource -> HKObjectType mapping to have the concept of _required_ and _optional_ object types.

This PR breaks out a third category of _supplementary_ object types.

----

This came with an observation in a clean installation that:
1. We go through the `VitalResource.heartrate` ask flow.
2. We granted permission to `HKQuantityType(.heartrate)`.
3. Expected behaviour:
    * Only `hasAskForPermission(.heartrate)` would report true.
3. Actual behaviour:
    * `hasAskForPermission(.heartrate)` reports true as expected.
    * [!] `hasAskForPermission(.activity)` unexpectedly reports true, because it listed `HKQuantityType(.heartrate)` as one of its optional object type.


----

This PR introduces an improved permission mapping ruleset:

1. Each sample type can only be claimed by one VitalResource as their _required_ or _optional_ types.

    * In other words, the VitalResource "owns" this sample type.
    * The split is still necessary here, since `VitalResource.sleep` cannot operate without `HKCategoryType(.sleepAnalysis)`. The same cannot be said for `HKQuantityType(.appleWristTemperature)`. 

1. Some `VitalResource`s may need to query object types they do not own. These types can be listed as _supplementary_ object types.

    * In other words, the VitalResource "borrows" a supplementary object type from its owner.
    * e.g. `VitalResource.activity` needs `HKQuantityType(.heartrate)` to compute heartrate statistics. But `HKQuantityType(.heartrate)` is owned by `VitalResource.heartRate`. So `.activity` can borrow the permission from `.heartRate` by listing `HKQuantityType(.heartrate)` as a supplementary type.


1. When answering the "has this VitalResource been asked" question, we **only** consider object types owned by the concerned VitalResource. The supplementary types are ignored.

This ruleset is checked by unit tests, so future additions would be validated to prevent any regression.


---

This might be a plausible contributor of SDK sync issues, aside from #134. Customer application logic might have decided not to prompt for permission, due to `hasAskForPermission(_:)` reporting a false positive.