### PR TITLE
VIT-6597: Caching SDK sync state

### DIFF
--- a/Sources/VitalCore/Core/Client/Data Models/Base Models/UserCRUD.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Base Models/UserCRUD.swift
@@ -31,6 +31,7 @@ public struct UserSDKSyncStateResponse: Decodable {
   public let requestStartDate: Date?
   public let requestEndDate: Date?
   public var perDeviceActivityTS: Bool = false
+  public var expiresIn: Int = 14400
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -38,6 +39,7 @@ public struct UserSDKSyncStateResponse: Decodable {
     self.requestStartDate = try container.decodeIfPresent(Date.self, forKey: .requestStartDate)
     self.requestEndDate = try container.decodeIfPresent(Date.self, forKey: .requestEndDate)
     self.perDeviceActivityTS = try container.decodeIfPresent(Bool.self, forKey: .perDeviceActivityTS) ?? false
+    self.expiresIn = try container.decodeIfPresent(Int.self, forKey: .expiresIn) ?? 14400
   }
 
   enum CodingKeys: String, CodingKey {
@@ -45,6 +47,7 @@ public struct UserSDKSyncStateResponse: Decodable {
     case requestStartDate = "request_start_date"
     case requestEndDate = "request_end_date"
     case perDeviceActivityTS = "per_device_activity_ts"
+    case expiresIn = "expires_in"
   }
 }
 
@@ -54,13 +57,11 @@ public enum Stage: String, Encodable {
 }
 
 public struct UserSDKSyncStateBody: Encodable {
-  public let stage: Stage
   public let tzinfo: String
   public let requestStartDate: Date?
   public let requestEndDate: Date?
 
-  public init(stage: Stage, tzinfo: String, requestStartDate: Date? = nil, requestEndDate: Date? = nil) {
-    self.stage = stage
+  public init(tzinfo: String, requestStartDate: Date? = nil, requestEndDate: Date? = nil) {
     self.tzinfo = tzinfo
     self.requestStartDate = requestStartDate
     self.requestEndDate = requestEndDate

--- a/Sources/VitalCore/JWT/VitalJWTAuth.swift
+++ b/Sources/VitalCore/JWT/VitalJWTAuth.swift
@@ -418,13 +418,14 @@ internal struct VitalSignInTokenClaims: Decodable {
 }
 
 /// A parking lot that holds waiting callers for token refresh flow to complete.
-private final class ParkingLot: @unchecked Sendable {
+@_spi(VitalSDKInternals)
+public final class ParkingLot: @unchecked Sendable {
   enum State: Sendable {
     case mustPark([UUID: CheckedContinuation<Void, Never>] = [:])
     case disabled
   }
 
-  enum Action {
+  public enum Action {
     case enable
     case disable
   }
@@ -432,7 +433,9 @@ private final class ParkingLot: @unchecked Sendable {
   private var state: State = .disabled
   private var lock = NSLock()
 
-  func tryTo(_ action: Action) -> Bool {
+  public init() {}
+
+  public func tryTo(_ action: Action) -> Bool {
     let (callersToRelease, hasTransitioned): ([CheckedContinuation<Void, Never>], Bool) = lock.withLock {
       switch (self.state, action) {
       case (.disabled, .enable):
@@ -461,7 +464,7 @@ private final class ParkingLot: @unchecked Sendable {
     return hasTransitioned
   }
 
-  func parkIfNeeded() async throws {
+  public func parkIfNeeded() async throws {
     let ticket = UUID()
 
     return try await withTaskCancellationHandler {

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -14,6 +14,7 @@ typealias HourlyStatisticsResultHandler = (Result<[VitalStatistics], Error>) -> 
 enum VitalHealthKitClientError: Error {
   case invalidInterval(Date, Date, context: StaticString)
   case invalidRemappedResource
+  case connectionPaused
 }
 
 struct VitalStatisticsError: Error {

--- a/Sources/VitalHealthKit/HealthKit/Models/LocalSyncState.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/LocalSyncState.swift
@@ -2,11 +2,17 @@ import Foundation
 import VitalCore
 
 internal struct LocalSyncState: Codable {
-  let historicalStart: Date
+  let historicalStageAnchor: Date
+  let defaultDaysToBackfill: Int
+
   let ingestionEnd: Date?
   let perDeviceActivityTS: Bool
 
   let expiresAt: Date
+
+  func historicalStartDate(for resource: VitalResource) -> Date {
+    Date.dateAgo(historicalStageAnchor, days: defaultDaysToBackfill)
+  }
 }
 
 

--- a/Sources/VitalHealthKit/HealthKit/Models/LocalSyncState.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/LocalSyncState.swift
@@ -1,0 +1,29 @@
+import Foundation
+import VitalCore
+
+internal struct LocalSyncState: Codable {
+  let historicalStart: Date
+  let ingestionEnd: Date?
+  let perDeviceActivityTS: Bool
+
+  let expiresAt: Date
+}
+
+
+struct SyncInstruction: CustomStringConvertible {
+  let stage: Stage
+  let query: Range<Date>
+
+  public var description: String {
+    return "\(stage): \(query.lowerBound) - \(query.upperBound)"
+  }
+
+  var taggedPayloadStage: TaggedPayload.Stage {
+    switch stage {
+    case .daily:
+      return .daily
+    case .historical:
+      return .historical(start: query.lowerBound, end: query.upperBound)
+    }
+  }
+}

--- a/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
+++ b/Sources/VitalHealthKit/HealthKit/Storage/VitalHealthKitStorage.swift
@@ -3,6 +3,8 @@ import VitalCore
 
 class VitalHealthKitStorage {
 
+  private static let localSyncState = "local_sync_state"
+
   private let anchorPrefix = "vital_anchor_"
   private let anchorsPrefix = "vital_anchors_"
 
@@ -109,6 +111,28 @@ class VitalHealthKitStorage {
     }
     
     return storeAnchor
+  }
+
+  func getLocalSyncState() -> LocalSyncState? {
+    guard let data = storage.read(Self.localSyncState) else {
+      return nil
+    }
+
+    do {
+      let encoder = JSONDecoder()
+      encoder.dateDecodingStrategy = .iso8601
+      return try encoder.decode(LocalSyncState.self, from: data)
+
+    } catch let error {
+      VitalLogger.healthKit.log(level: .error, "[Storage] Failed to decode HistoricalStage: \(error)")
+      return nil
+    }
+  }
+
+  func setLocalSyncState(_ newValue: LocalSyncState) throws {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    storage.store(try encoder.encode(newValue), Self.localSyncState)
   }
 
   func remove(key: String) {


### PR DESCRIPTION
* Introduce a `LocalSyncState` that by default has 4-hour TTL.

    * This allows us to revalidate `/sdk_sync_state` only when: (1) we do not have a known `LocalSyncState`; or that (2) the TTL has expired.

* Historical start date is now memoized, so all resources will use the exact same start date.
    * Exception: When the user ingestion start date was set, that value from backend always takes precedence.