### PR TITLE
VIT-6603: Change iOS SDK default log level to error

### DIFF
--- a/Sources/VitalCore/Core/Log/PersistentLog.swift
+++ b/Sources/VitalCore/Core/Log/PersistentLog.swift
@@ -60,11 +60,13 @@ public final class VitalPersistentLogger: @unchecked Sendable {
 
     case (false, .some):
       _shared = nil
+      VitalLogger.logLevelRequest.persistentLogger = .error
       return nil
 
     case (true, nil):
       let persistentLogger = VitalPersistentLogger()
       _shared = persistentLogger
+      VitalLogger.logLevelRequest.persistentLogger = .info
       return (persistentLogger, true)
 
     case let (true, logger?):


### PR DESCRIPTION
The loggers are default to `.info`.
This means all `log()` calls would assemble the log message string in release build, even if VitalPersistentLogger is turned off.

This PR changes the default log level to `.error`, so that _most_ `log()` calls would become almost a no-op (check the log level, then quits early, since most logs are at `.info` level).