### PR TITLE
VIT-6623: Catch up with API deprecations Pt.1

### DIFF
--- a/Examples/iOS/Devices Tab/DeviceConnection.swift
+++ b/Examples/iOS/Devices Tab/DeviceConnection.swift
@@ -9,8 +9,8 @@ import VitalCore
 enum DeviceConnection {}
 
 enum Reading: Equatable, Hashable, IdentifiableByHashable {
-  case bloodPressure(BloodPressureSample)
-  case glucose(QuantitySample)
+  case bloodPressure(LocalBloodPressureSample)
+  case glucose(LocalQuantitySample)
   
   var isBloodPressure: Bool {
     switch self {
@@ -21,7 +21,7 @@ enum Reading: Equatable, Hashable, IdentifiableByHashable {
     }
   }
   
-  var glucose: QuantitySample? {
+  var glucose: LocalQuantitySample? {
     switch self {
       case .bloodPressure:
         return nil
@@ -30,7 +30,7 @@ enum Reading: Equatable, Hashable, IdentifiableByHashable {
     }
   }
   
-  var bloodPressure: BloodPressureSample? {
+  var bloodPressure: LocalBloodPressureSample? {
     switch self {
       case let .bloodPressure(bloodPressurePoint):
         return bloodPressurePoint

--- a/Examples/iOS/Devices Tab/DevicesExample.swift
+++ b/Examples/iOS/Devices Tab/DevicesExample.swift
@@ -29,7 +29,7 @@ extension DevicesExample {
     case navigateToLibre1Connection(String?)
     
     case startScanning
-    case successScanning([QuantitySample])
+    case successScanning([LocalQuantitySample])
     case failureScanning(String)
   }
   
@@ -60,7 +60,7 @@ private let reducer = Reducer<DevicesExample.State, DevicesExample.Action, Devic
       
     case .startScanning:
       
-      let effect = Effect<[QuantitySample], Error>.task {
+      let effect = Effect<[LocalQuantitySample], Error>.task {
         
         let read = try await environment.libre1.read()
         return read.samples

--- a/Examples/iOS/Devices Tab/Libre1Connection.swift
+++ b/Examples/iOS/Devices Tab/Libre1Connection.swift
@@ -6,7 +6,7 @@ import NukeUI
 import Combine
 import VitalCore
 
-extension QuantitySample: IdentifiableByHashable {}
+extension LocalQuantitySample: IdentifiableByHashable {}
 
 enum Libre1Connection {}
 
@@ -144,7 +144,7 @@ extension Libre1Connection {
             Spacer(minLength: 15)
             
             List {
-              ForEach(viewStore.read?.samples ?? []) { (sample: QuantitySample) in
+              ForEach(viewStore.read?.samples ?? []) { (sample: LocalQuantitySample) in
                 
                 HStack {
                   VStack {

--- a/Sources/VitalCore/Core/Client/Data Models/Base Models/BloodPressureDataPoint.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Base Models/BloodPressureDataPoint.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-public struct BloodPressureDataPoint: Equatable, Decodable, Hashable {
-  public let id: Int?
+public struct BloodPressureSample: Equatable, Decodable, Hashable {
   public let timestamp: Date
   
   public let systolic: Float
@@ -9,4 +8,12 @@ public struct BloodPressureDataPoint: Equatable, Decodable, Hashable {
   
   public let type: String?
   public let unit: String
+
+  public init(timestamp: Date, systolic: Float, diastolic: Float, type: String?, unit: String) {
+    self.timestamp = timestamp
+    self.systolic = systolic
+    self.diastolic = diastolic
+    self.type = type
+    self.unit = unit
+  }
 }

--- a/Sources/VitalCore/Core/Client/Data Models/Base Models/ResourceData.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Base Models/ResourceData.swift
@@ -31,8 +31,8 @@ public enum ProcessedResourceData: Equatable, Encodable {
 }
 
 public enum NutritionData: Equatable, Encodable {
-  case water([QuantitySample])
-  case caffeine([QuantitySample])
+  case water([LocalQuantitySample])
+  case caffeine([LocalQuantitySample])
   
   public var payload: Encodable {
     switch self {
@@ -63,13 +63,13 @@ public enum NutritionData: Equatable, Encodable {
 }
 
 public enum TimeSeriesData: Equatable, Encodable {
-  case glucose([QuantitySample])
-  case bloodOxygen([QuantitySample])
-  case bloodPressure([BloodPressureSample])
-  case heartRate([QuantitySample])
-  case heartRateVariability([QuantitySample])
+  case glucose([LocalQuantitySample])
+  case bloodOxygen([LocalQuantitySample])
+  case bloodPressure([LocalBloodPressureSample])
+  case heartRate([LocalQuantitySample])
+  case heartRateVariability([LocalQuantitySample])
   case nutrition(NutritionData)
-  case mindfulSession([QuantitySample])
+  case mindfulSession([LocalQuantitySample])
   
   
   public var payload: Encodable {

--- a/Sources/VitalCore/Core/Client/Data Models/Base Models/TimeSeriesDataPoint.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Base Models/TimeSeriesDataPoint.swift
@@ -1,10 +1,53 @@
 import Foundation
 
-public struct TimeSeriesDataPoint: Equatable, Decodable, Hashable {
-  public let id: Int?
+public struct ScalarSample: Equatable, Decodable {
   public let timestamp: Date
-  
+
   public let value: Float
   public let type: String?
-  public let unit: String?
+  public let unit: String
+
+  public init(timestamp: Date, value: Float, type: String?, unit: String) {
+    self.timestamp = timestamp
+    self.value = value
+    self.type = type
+    self.unit = unit
+  }
+}
+
+public struct IntervalSample: Equatable, Decodable, Hashable {
+  public let start: Date
+  public let end: Date
+
+  public let value: Float
+  public let type: String?
+  public let unit: String
+
+  public init(start: Date, end: Date, value: Float, type: String?, unit: String) {
+    self.start = start
+    self.end = end
+    self.value = value
+    self.type = type
+    self.unit = unit
+  }
+}
+
+public struct GroupedSamplesResponse<Sample: Equatable & Decodable>: Equatable, Decodable {
+  public let groups: [GroupedSamples<Sample>]
+  public let next: String?
+
+  public init(groups: [GroupedSamples<Sample>], next: String?) {
+    self.groups = groups
+    self.next = next
+  }
+}
+
+public struct GroupedSamples<Sample: Equatable & Decodable>: Equatable, Decodable {
+  public let source: Source
+  public let data: [Sample]
+
+  public init(source: Source, data: [Sample]) {
+    self.source = source
+    self.data = data
+  }
 }

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/ActivityPatch.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/ActivityPatch.swift
@@ -3,12 +3,12 @@ import Foundation
 public struct ActivityPatch: Equatable, Encodable {
   public struct Activity: Equatable, Encodable {
     public var daySummary: DaySummary? = nil
-    public var activeEnergyBurned: [QuantitySample] = []
-    public var basalEnergyBurned: [QuantitySample] = []
-    public var steps: [QuantitySample] = []
-    public var floorsClimbed: [QuantitySample] = []
-    public var distanceWalkingRunning: [QuantitySample] = []
-    public var vo2Max: [QuantitySample] = []
+    public var activeEnergyBurned: [LocalQuantitySample] = []
+    public var basalEnergyBurned: [LocalQuantitySample] = []
+    public var steps: [LocalQuantitySample] = []
+    public var floorsClimbed: [LocalQuantitySample] = []
+    public var distanceWalkingRunning: [LocalQuantitySample] = []
+    public var vo2Max: [LocalQuantitySample] = []
 
     public var isNotEmpty: Bool {
       (daySummary.map(\.isNotEmpty) ?? false) || !activeEnergyBurned.isEmpty ||
@@ -19,12 +19,12 @@ public struct ActivityPatch: Equatable, Encodable {
 
     public init(
       daySummary: DaySummary? = nil,
-      activeEnergyBurned: [QuantitySample] = [],
-      basalEnergyBurned: [QuantitySample] = [],
-      steps: [QuantitySample] = [],
-      floorsClimbed: [QuantitySample] = [],
-      distanceWalkingRunning: [QuantitySample] = [],
-      vo2Max: [QuantitySample] = []
+      activeEnergyBurned: [LocalQuantitySample] = [],
+      basalEnergyBurned: [LocalQuantitySample] = [],
+      steps: [LocalQuantitySample] = [],
+      floorsClimbed: [LocalQuantitySample] = [],
+      distanceWalkingRunning: [LocalQuantitySample] = [],
+      vo2Max: [LocalQuantitySample] = []
     ) {
       self.daySummary = daySummary
       self.activeEnergyBurned = activeEnergyBurned

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/BloodPressureSample.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/BloodPressureSample.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-public struct BloodPressureSample: Equatable, Hashable, Encodable {
-  public let systolic: QuantitySample
-  public let diastolic: QuantitySample
-  public let pulse: QuantitySample?
+public struct LocalBloodPressureSample: Equatable, Hashable, Encodable {
+  public let systolic: LocalQuantitySample
+  public let diastolic: LocalQuantitySample
+  public let pulse: LocalQuantitySample?
   
   public init(
-    systolic: QuantitySample,
-    diastolic: QuantitySample,
-    pulse: QuantitySample?
+    systolic: LocalQuantitySample,
+    diastolic: LocalQuantitySample,
+    pulse: LocalQuantitySample?
   ) {
     self.systolic = systolic
     self.diastolic = diastolic

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/BodyPatch.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/BodyPatch.swift
@@ -1,10 +1,10 @@
 public struct BodyPatch: Equatable, Encodable {
-  public let bodyMass: [QuantitySample]
-  public let bodyFatPercentage: [QuantitySample]
+  public let bodyMass: [LocalQuantitySample]
+  public let bodyFatPercentage: [LocalQuantitySample]
   
   public  init(
-    bodyMass: [QuantitySample] = [],
-    bodyFatPercentage: [QuantitySample] = []
+    bodyMass: [LocalQuantitySample] = [],
+    bodyFatPercentage: [LocalQuantitySample] = []
   ) {
     self.bodyMass = bodyMass
     self.bodyFatPercentage = bodyFatPercentage

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/QuantitySample.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/QuantitySample.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct QuantitySample: Equatable, Hashable, Encodable {
+public struct LocalQuantitySample: Equatable, Hashable, Encodable {
   
   public let id: String?
   public var value: Double
@@ -68,7 +68,7 @@ public struct QuantitySample: Equatable, Hashable, Encodable {
     )
   }
 
-  public static func == (lhs: QuantitySample, rhs: QuantitySample) -> Bool {
+  public static func == (lhs: LocalQuantitySample, rhs: LocalQuantitySample) -> Bool {
     lhs.id == rhs.id &&
     lhs.value == rhs.value &&
     lhs.startDate == rhs.startDate &&

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/SleepPatch.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/SleepPatch.swift
@@ -5,13 +5,13 @@ public struct SleepPatch: Equatable, Encodable {
     public struct SleepStages: Equatable, Encodable {
 
       
-      public var unspecifiedSleepSamples: [QuantitySample] = []
-      public var awakeSleepSamples: [QuantitySample] = []
-      public var deepSleepSamples: [QuantitySample] = []
-      public var lightSleepSamples: [QuantitySample] = []
-      public var remSleepSamples: [QuantitySample] = []
-      public var inBedSleepSamples: [QuantitySample] = []
-      public var unknownSleepSamples: [QuantitySample] = []
+      public var unspecifiedSleepSamples: [LocalQuantitySample] = []
+      public var awakeSleepSamples: [LocalQuantitySample] = []
+      public var deepSleepSamples: [LocalQuantitySample] = []
+      public var lightSleepSamples: [LocalQuantitySample] = []
+      public var remSleepSamples: [LocalQuantitySample] = []
+      public var inBedSleepSamples: [LocalQuantitySample] = []
+      public var unknownSleepSamples: [LocalQuantitySample] = []
       
       public init() {}
     }
@@ -22,12 +22,12 @@ public struct SleepPatch: Equatable, Encodable {
     public var sourceBundle: String
     public var productType: String
     
-    public var heartRate: [QuantitySample] = []
-    public var restingHeartRate: [QuantitySample] = []
-    public var heartRateVariability: [QuantitySample] = []
-    public var oxygenSaturation: [QuantitySample] = []
-    public var respiratoryRate: [QuantitySample] = []
-    public var wristTemperature: [QuantitySample] = []
+    public var heartRate: [LocalQuantitySample] = []
+    public var restingHeartRate: [LocalQuantitySample] = []
+    public var heartRateVariability: [LocalQuantitySample] = []
+    public var oxygenSaturation: [LocalQuantitySample] = []
+    public var respiratoryRate: [LocalQuantitySample] = []
+    public var wristTemperature: [LocalQuantitySample] = []
 
     public var sleepStages: SleepStages = .init()
 
@@ -41,11 +41,11 @@ public struct SleepPatch: Equatable, Encodable {
       endDate: Date,
       sourceBundle: String,
       productType: String,
-      heartRate: [QuantitySample] = [],
-      restingHeartRate: [QuantitySample] = [],
-      heartRateVariability: [QuantitySample] = [],
-      oxygenSaturation: [QuantitySample] = [],
-      respiratoryRate: [QuantitySample] = [],
+      heartRate: [LocalQuantitySample] = [],
+      restingHeartRate: [LocalQuantitySample] = [],
+      heartRateVariability: [LocalQuantitySample] = [],
+      oxygenSaturation: [LocalQuantitySample] = [],
+      respiratoryRate: [LocalQuantitySample] = [],
       sleepStages: SleepStages = .init()
     ) {
       self.id = id

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/TaggedPayload.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/TaggedPayload.swift
@@ -58,7 +58,7 @@ public extension TaggedPayload {
   
   enum Data: Encodable {
     public enum Vitals: Encodable {
-      case glucose([QuantitySample])
+      case glucose([LocalQuantitySample])
     }
     
     case profile(ProfilePatch)

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/WorkoutPatch.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/WorkoutPatch.swift
@@ -15,8 +15,8 @@ public struct WorkoutPatch: Equatable, Encodable {
     public let ascentElevation: Double?
     public let descentElevation: Double?
 
-    public var heartRate: [QuantitySample] = []
-    public var respiratoryRate: [QuantitySample] = []
+    public var heartRate: [LocalQuantitySample] = []
+    public var respiratoryRate: [LocalQuantitySample] = []
 
     public var sourceType: SourceType {
       return .infer(sourceBundle: sourceBundle, productType: productType)
@@ -34,8 +34,8 @@ public struct WorkoutPatch: Equatable, Encodable {
       distance: Double,
       ascentElevation: Double?,
       descentElevation: Double?,
-      heartRate: [QuantitySample] = [],
-      respiratoryRate: [QuantitySample] = []
+      heartRate: [LocalQuantitySample] = [],
+      respiratoryRate: [LocalQuantitySample] = []
     ) {
       self.id = id
       self.startDate = startDate

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum SimpleTimeSeriesResource {
+public enum ScalarTimeseriesResource {
   case glucose
   case heartRate
   case bloodOxygen
@@ -57,12 +57,12 @@ public extension VitalClient.TimeSeries {
   }
   
   func get(
-    resource: SimpleTimeSeriesResource,
+    resource: ScalarTimeseriesResource,
     startDate: Date,
     endDate: Date? = nil,
     provider: UserConnection.Slug? = nil
-  ) async throws -> [TimeSeriesDataPoint] {
-    
+  ) async throws -> GroupedSamplesResponse<ScalarSample> {
+
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
 
@@ -71,8 +71,8 @@ public extension VitalClient.TimeSeries {
     
     let fullPath = await makePath(for: path, userId: userId)
     
-    let request: Request<[TimeSeriesDataPoint]> = .init(path: fullPath, method: .get, query: query)
-    
+    let request: Request<GroupedSamplesResponse<ScalarSample>> = .init(path: fullPath, method: .get, query: query)
+
     let response = try await configuration.apiClient.send(request)
     return response.value
   }
@@ -81,15 +81,15 @@ public extension VitalClient.TimeSeries {
     startDate: Date,
     endDate: Date? = nil,
     provider: UserConnection.Slug? = nil
-  ) async throws -> [BloodPressureDataPoint] {
-    
+  ) async throws -> GroupedSamplesResponse<BloodPressureSample> {
+
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
 
     let path = await makePath(for: "blood_pressure", userId: userId)
     let query = makeBaseQuery(startDate: startDate, endDate: endDate, provider: provider)
     
-    let request: Request<[BloodPressureDataPoint]> = .init(path: path, method: .get, query: query)
+    let request: Request<GroupedSamplesResponse<BloodPressureSample>> = .init(path: path, method: .get, query: query)
     let response = try await configuration.apiClient.send(request)
     
     return response.value
@@ -106,7 +106,7 @@ public extension VitalClient.TimeSeries {
       .append(self.resource)
       .append(userId)
 
-    return prefix.append(resource)
+    return prefix.append(resource).append("grouped")
   }
   
   func makeQuery(

--- a/Sources/VitalDevices/DeviceReading/GlucoseMeter1808.swift
+++ b/Sources/VitalDevices/DeviceReading/GlucoseMeter1808.swift
@@ -3,10 +3,10 @@ import CombineCoreBluetooth
 import Combine
 
 public protocol GlucoseMeterReadable: DevicePairable {
-  func read(device: ScannedDevice) -> AnyPublisher<[QuantitySample], Error>
+  func read(device: ScannedDevice) -> AnyPublisher<[LocalQuantitySample], Error>
 }
 
-class GlucoseMeter1808: GATTMeter<QuantitySample>, GlucoseMeterReadable {
+class GlucoseMeter1808: GATTMeter<LocalQuantitySample>, GlucoseMeterReadable {
   init(
     manager: CentralManager = .live(),
     queue: DispatchQueue
@@ -21,7 +21,7 @@ class GlucoseMeter1808: GATTMeter<QuantitySample>, GlucoseMeterReadable {
   }
 }
 
-private func toGlucoseReading(data: Data) -> QuantitySample? {
+private func toGlucoseReading(data: Data) -> LocalQuantitySample? {
   /// Record size is minimum 10 bytes (all mandatory fields)
   /// Size can vary based on flags encoded in the first byte.
   /// Refer to Bluetooth Glucose Service specification for more information.
@@ -89,7 +89,7 @@ private func toGlucoseReading(data: Data) -> QuantitySample? {
     unit = "mg/dL"
   }
 
-  return QuantitySample(
+  return LocalQuantitySample(
     // Prefixed with epoch in seconds to avoid sequence number conflicts
     // (due to new device and/or device reset)
     id: "\(date.timeIntervalSince1970.rounded())-\(sequenceNumber)",

--- a/Sources/VitalDevices/DeviceReading/Libre1Reader.swift
+++ b/Sources/VitalDevices/DeviceReading/Libre1Reader.swift
@@ -36,7 +36,7 @@ public class Libre1Reader {
       nfc.startSession()
     }
     
-    let samples = payload.1.map(QuantitySample.init)
+    let samples = payload.1.map(LocalQuantitySample.init)
     let sensor = Libre1Sensor.init(sensor: payload.0)
     
     return Libre1Read(samples: samples, sensor: sensor)
@@ -44,10 +44,10 @@ public class Libre1Reader {
 }
 
 public struct Libre1Read: Equatable, Encodable {
-  public let samples: [QuantitySample]
+  public let samples: [LocalQuantitySample]
   public let sensor: Libre1Sensor
   
-  public init(samples: [QuantitySample], sensor: Libre1Sensor) {
+  public init(samples: [LocalQuantitySample], sensor: Libre1Sensor) {
     self.samples = samples
     self.sensor = sensor
   }

--- a/Sources/VitalDevices/Extensions/QuantitySample+Glucose.swift
+++ b/Sources/VitalDevices/Extensions/QuantitySample+Glucose.swift
@@ -1,6 +1,6 @@
 import VitalCore
 
-/// We use this approach so that the JSON payload for `QuantitySample`
+/// We use this approach so that the JSON payload for `LocalQuantitySample`
 /// looks nicer:
 ///
 /// ```
@@ -37,7 +37,7 @@ private struct FreestyleLibreGlucoseDigest: Encodable {
   }
 }
 
-extension QuantitySample {
+extension LocalQuantitySample {
   init(glucose: Glucose) {
     self.init(
       id: String(glucose.id),

--- a/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
@@ -2,7 +2,7 @@ import HealthKit
 import VitalCore
 
 extension ActivityPatch.Activity {
-  init(sampleType: HKSampleType, date: Date, samples: [QuantitySample]) {
+  init(sampleType: HKSampleType, date: Date, samples: [LocalQuantitySample]) {
     switch sampleType {
       case .quantityType(forIdentifier: .activeEnergyBurned)!:
         self.init(activeEnergyBurned: samples)
@@ -29,14 +29,14 @@ extension ActivityPatch.Activity {
 }
 
 extension ActivityPatch {
-  init(sampleType: HKSampleType, samples: [QuantitySample]) {
+  init(sampleType: HKSampleType, samples: [LocalQuantitySample]) {
     
     let allDates: Set<Date> = Set(samples.reduce([]) { acc, next in
       acc + [next.startDate.dayStart]
     })
     
     let activities = allDates.map { date -> ActivityPatch.Activity in
-      func filter(_ samples: [QuantitySample]) -> [QuantitySample] {
+      func filter(_ samples: [LocalQuantitySample]) -> [LocalQuantitySample] {
         samples.filter { $0.startDate.dayStart == date }
       }
       
@@ -49,7 +49,7 @@ extension ActivityPatch {
 }
 
 extension BodyPatch {
-  init(sampleType: HKSampleType, samples: [QuantitySample]) {
+  init(sampleType: HKSampleType, samples: [LocalQuantitySample]) {
     switch sampleType {
       case .quantityType(forIdentifier: .bodyMass)!:
         self.init(bodyMass: samples)
@@ -100,7 +100,7 @@ extension HKSampleType {
   }
 }
 
-extension BloodPressureSample {
+extension LocalBloodPressureSample {
   init?(
     _ sample: HKSample
   ) {
@@ -123,8 +123,8 @@ extension BloodPressureSample {
       correlation.objects.count == 2,
       let diastolic = correlation.objects.first(where: testType(.bloodPressureDiastolic)),
       let systolic = correlation.objects.first(where: testType(.bloodPressureSystolic)),
-      let diastolicSample = QuantitySample(diastolic),
-      let systolicSample = QuantitySample(systolic)
+      let diastolicSample = LocalQuantitySample(diastolic),
+      let systolicSample = LocalQuantitySample(systolic)
     else {
       return nil
     }
@@ -137,7 +137,7 @@ extension BloodPressureSample {
   }
 }
 
-extension QuantitySample {
+extension LocalQuantitySample {
   init?(
     _ sample: HKSample
   ) {
@@ -180,7 +180,7 @@ private func generateIdForServer(for startDate: Date, endDate: Date, type: Strin
   return id.sha256()
 }
 
-extension QuantitySample {
+extension LocalQuantitySample {
   init?(
     _ statistics: VitalStatistics,
     _ sampleType: HKQuantityType
@@ -496,7 +496,7 @@ extension WorkoutPatch.Workout {
   }
 }
 
-extension QuantitySample {
+extension LocalQuantitySample {
   public init(categorySample: HKCategorySample) {
     self.init(
       id: categorySample.uuid.uuidString,
@@ -511,8 +511,8 @@ extension QuantitySample {
   }
 }
 
-extension QuantitySample {
-  static func fromMindfulSession(sample: HKSample) -> QuantitySample? {
+extension LocalQuantitySample {
+  static func fromMindfulSession(sample: HKSample) -> LocalQuantitySample? {
 
     guard let minutes = Date.differenceInMinutes(startDate: sample.startDate, endDate: sample.endDate) else {
       return nil

--- a/Tests/VitalDevicesTests/Libre1ReaderTests.swift
+++ b/Tests/VitalDevicesTests/Libre1ReaderTests.swift
@@ -29,7 +29,7 @@ class Libre1ReaderTests: XCTestCase {
     let expectSensor = expect["sensor"] as! [String : AnyHashable]
     let dictionarySensor = dictionary["sensor"] as! [String : AnyHashable]
 
-    XCTAssertEqual(expect["samples"], dictionary["samples"] as! [QuantitySample])
+    XCTAssertEqual(expect["samples"], dictionary["samples"] as! [LocalQuantitySample])
     XCTAssertEqual(expectSensor["serial"], dictionarySensor["serial"])
     XCTAssertEqual(expectSensor["maxLife"], dictionarySensor["maxLife"])
     XCTAssertEqual(expectSensor["age"], dictionarySensor["age"])

--- a/Tests/VitalHealthKitTests/VitalHealthKitFreeFunctions.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitFreeFunctions.swift
@@ -10,21 +10,21 @@ class VitalHealthKitFreeFunctionsTests: XCTestCase {
     let calendar = Calendar.current
     let date = calendar.date(bySettingHour: 9, minute: 0, second: 0, of: Date())!
 
-    let s1: QuantitySample = .init(value: 10, date: date, unit: "")
-    let s2: QuantitySample = .init(value: 10, date: date.adding(minutes: 14), unit: "")
+    let s1: LocalQuantitySample = .init(value: 10, date: date, unit: "")
+    let s2: LocalQuantitySample = .init(value: 10, date: date.adding(minutes: 14), unit: "")
     
-    let s3: QuantitySample = .init(value: 5, date: date.adding(minutes: 15), unit: "")
-    let s4: QuantitySample = .init(value: 5, date: date.adding(minutes: 29), unit: "")
+    let s3: LocalQuantitySample = .init(value: 5, date: date.adding(minutes: 15), unit: "")
+    let s4: LocalQuantitySample = .init(value: 5, date: date.adding(minutes: 29), unit: "")
     
-    let s5: QuantitySample = .init(value: 1, date: date.adding(minutes: 30), unit: "")
-    let s6: QuantitySample = .init(value: 1, date: date.adding(minutes: 44), unit: "")
+    let s5: LocalQuantitySample = .init(value: 1, date: date.adding(minutes: 30), unit: "")
+    let s6: LocalQuantitySample = .init(value: 1, date: date.adding(minutes: 44), unit: "")
     
-    let s7: QuantitySample = .init(value: 2, date: date.adding(minutes: 45), unit: "")
-    let s8: QuantitySample = .init(value: 2, date: date.adding(minutes: 59), unit: "")
+    let s7: LocalQuantitySample = .init(value: 2, date: date.adding(minutes: 45), unit: "")
+    let s8: LocalQuantitySample = .init(value: 2, date: date.adding(minutes: 59), unit: "")
     
-    let s9: QuantitySample = .init(value: 1, date: date.adding(minutes: 60), unit: "")
+    let s9: LocalQuantitySample = .init(value: 1, date: date.adding(minutes: 60), unit: "")
   
-    func assert(array: [QuantitySample]) {
+    func assert(array: [LocalQuantitySample]) {
       XCTAssertTrue(array.count == 5)
       XCTAssertTrue(array[0].value == 20)
       XCTAssertTrue(array[1].value == 10)
@@ -44,21 +44,21 @@ class VitalHealthKitFreeFunctionsTests: XCTestCase {
     let calendar = Calendar.current
     let date = calendar.date(bySettingHour: 9, minute: 0, second: 0, of: Date())!
     
-    let s1: QuantitySample = .init(value: 10, date: date, sourceBundle: "1", unit: "")
-    let s2: QuantitySample = .init(value: 10, date: date.adding(minutes: 14), sourceBundle: "1", unit: "")
+    let s1: LocalQuantitySample = .init(value: 10, date: date, sourceBundle: "1", unit: "")
+    let s2: LocalQuantitySample = .init(value: 10, date: date.adding(minutes: 14), sourceBundle: "1", unit: "")
     
-    let s3: QuantitySample = .init(value: 5, date: date.adding(minutes: 15), sourceBundle: "1", unit: "")
-    let s4: QuantitySample = .init(value: 5, date: date.adding(minutes: 29), sourceBundle: "1", unit: "")
+    let s3: LocalQuantitySample = .init(value: 5, date: date.adding(minutes: 15), sourceBundle: "1", unit: "")
+    let s4: LocalQuantitySample = .init(value: 5, date: date.adding(minutes: 29), sourceBundle: "1", unit: "")
     
-    let s5: QuantitySample = .init(value: 1, date: date.adding(minutes: 30), sourceBundle: "2", unit: "")
-    let s6: QuantitySample = .init(value: 1, date: date.adding(minutes: 44), sourceBundle: "2", unit: "")
+    let s5: LocalQuantitySample = .init(value: 1, date: date.adding(minutes: 30), sourceBundle: "2", unit: "")
+    let s6: LocalQuantitySample = .init(value: 1, date: date.adding(minutes: 44), sourceBundle: "2", unit: "")
     
-    let s7: QuantitySample = .init(value: 1, date: date.adding(minutes: 45), sourceBundle: "3", unit: "")
-    let s8: QuantitySample = .init(value: 2, date: date.adding(minutes: 50), sourceBundle: "3", unit: "")
-    let s9: QuantitySample = .init(value: 3, date: date.adding(minutes: 59), sourceBundle: "3", unit: "")
+    let s7: LocalQuantitySample = .init(value: 1, date: date.adding(minutes: 45), sourceBundle: "3", unit: "")
+    let s8: LocalQuantitySample = .init(value: 2, date: date.adding(minutes: 50), sourceBundle: "3", unit: "")
+    let s9: LocalQuantitySample = .init(value: 3, date: date.adding(minutes: 59), sourceBundle: "3", unit: "")
     
     
-    func assert(array: [QuantitySample]) {
+    func assert(array: [LocalQuantitySample]) {
       XCTAssertTrue(array.count == 4)
       XCTAssertTrue(array[0].value == 20)
       XCTAssertTrue(array[1].value == 10)
@@ -77,7 +77,7 @@ class VitalHealthKitFreeFunctionsTests: XCTestCase {
   func testAccumulateRealisticExample() {
     let calendar = Calendar.current
 
-    func makeSample(hour: Int, minute: Int, value: Double) -> QuantitySample {
+    func makeSample(hour: Int, minute: Int, value: Double) -> LocalQuantitySample {
       let date = calendar.date(bySettingHour: hour, minute: minute, second: 0, of: Date())!
       return .init(value: value, date: date, sourceBundle: "1", unit: "")
     }
@@ -136,8 +136,8 @@ class VitalHealthKitFreeFunctionsTests: XCTestCase {
     let calendar = Calendar.current
     let date = calendar.date(bySettingHour: 9, minute: 0, second: 0, of: Date())!
     
-    let s1: QuantitySample = .init(value: 12, date: date, unit: "")
-    let s2: QuantitySample = .init(value: 10, date: date.adding(seconds: 1), unit: "")
+    let s1: LocalQuantitySample = .init(value: 12, date: date, unit: "")
+    let s2: LocalQuantitySample = .init(value: 10, date: date.adding(seconds: 1), unit: "")
     
     let array = average([s1, s2], calendar: calendar)
     
@@ -150,17 +150,17 @@ class VitalHealthKitFreeFunctionsTests: XCTestCase {
     let calendar = Calendar.current
     let date = calendar.date(bySettingHour: 9, minute: 0, second: 0, of: Date())!
     
-    let s1: QuantitySample = .init(value: 12, date: date, unit: "")
-    let s2: QuantitySample = .init(value: 1, date: date.adding(seconds: 1), unit: "")
-    let s3: QuantitySample = .init(value: 15, date: date.adding(seconds: 3), unit: "")
-    let s4: QuantitySample = .init(value: 11, date: date.adding(seconds: 4), unit: "")
+    let s1: LocalQuantitySample = .init(value: 12, date: date, unit: "")
+    let s2: LocalQuantitySample = .init(value: 1, date: date.adding(seconds: 1), unit: "")
+    let s3: LocalQuantitySample = .init(value: 15, date: date.adding(seconds: 3), unit: "")
+    let s4: LocalQuantitySample = .init(value: 11, date: date.adding(seconds: 4), unit: "")
 
-    let s5: QuantitySample = .init(value: 10, date: date.adding(seconds: 6), unit: "")
-    let s6: QuantitySample = .init(value: 11, date: date.adding(seconds: 7), unit: "")
-    let s7: QuantitySample = .init(value: 12, date: date.adding(seconds: 8), unit: "")
-    let s8: QuantitySample = .init(value: 13, date: date.adding(seconds: 9), unit: "")
+    let s5: LocalQuantitySample = .init(value: 10, date: date.adding(seconds: 6), unit: "")
+    let s6: LocalQuantitySample = .init(value: 11, date: date.adding(seconds: 7), unit: "")
+    let s7: LocalQuantitySample = .init(value: 12, date: date.adding(seconds: 8), unit: "")
+    let s8: LocalQuantitySample = .init(value: 13, date: date.adding(seconds: 9), unit: "")
         
-    func assert(array: [QuantitySample]) {
+    func assert(array: [LocalQuantitySample]) {
       XCTAssertTrue(array.count == 4)
       XCTAssertTrue(array[0].value == 9.75)
       XCTAssertTrue(array[1].value == 1)
@@ -179,18 +179,18 @@ class VitalHealthKitFreeFunctionsTests: XCTestCase {
     let calendar = Calendar.current
     let date = calendar.date(bySettingHour: 9, minute: 0, second: 0, of: Date())!
     
-    let s1: QuantitySample = .init(value: 12, date: date, sourceBundle: "1", unit: "")
-    let s2: QuantitySample = .init(value: 1, date: date.adding(seconds: 1), sourceBundle: "1", unit: "")
-    let s3: QuantitySample = .init(value: 15, date: date.adding(seconds: 3), sourceBundle: "1", unit: "")
-    let s4: QuantitySample = .init(value: 11, date: date.adding(seconds: 4), sourceBundle: "1", unit: "")
+    let s1: LocalQuantitySample = .init(value: 12, date: date, sourceBundle: "1", unit: "")
+    let s2: LocalQuantitySample = .init(value: 1, date: date.adding(seconds: 1), sourceBundle: "1", unit: "")
+    let s3: LocalQuantitySample = .init(value: 15, date: date.adding(seconds: 3), sourceBundle: "1", unit: "")
+    let s4: LocalQuantitySample = .init(value: 11, date: date.adding(seconds: 4), sourceBundle: "1", unit: "")
     
-    let s5: QuantitySample = .init(value: 9, date: date.adding(seconds: 6), sourceBundle: "2", unit: "")
-    let s6: QuantitySample = .init(value: 11, date: date.adding(seconds: 7), sourceBundle: "2", unit: "")
-    let s7: QuantitySample = .init(value: 7, date: date.adding(seconds: 8), sourceBundle: "2", unit: "")
+    let s5: LocalQuantitySample = .init(value: 9, date: date.adding(seconds: 6), sourceBundle: "2", unit: "")
+    let s6: LocalQuantitySample = .init(value: 11, date: date.adding(seconds: 7), sourceBundle: "2", unit: "")
+    let s7: LocalQuantitySample = .init(value: 7, date: date.adding(seconds: 8), sourceBundle: "2", unit: "")
     
-    let s8: QuantitySample = .init(value: 13, date: date.adding(seconds: 9), sourceBundle: "3", unit: "")
+    let s8: LocalQuantitySample = .init(value: 13, date: date.adding(seconds: 9), sourceBundle: "3", unit: "")
     
-    func assert(array: [QuantitySample]) {
+    func assert(array: [LocalQuantitySample]) {
       XCTAssertTrue(array.count == 7)
       XCTAssertTrue(array[0].value == 9.75)
       XCTAssertTrue(array[1].value == 1)
@@ -226,27 +226,27 @@ class VitalHealthKitFreeFunctionsTests: XCTestCase {
       ))
     }
 
-    func makeQuantitySamples(for dates: [FloatingDate]) -> [QuantitySample] {
+    func makeLocalQuantitySamples(for dates: [FloatingDate]) -> [LocalQuantitySample] {
       dates.enumerated().flatMap { entry in
         [
-          QuantitySample(
+          LocalQuantitySample(
             value: 100 + Double(entry.offset) * 10,
             // Right on start-of-day
             date: calendar.startOfDay(entry.element),
             unit: "unittest"
           ),
-          QuantitySample(
+          LocalQuantitySample(
             value: 100 + Double(entry.offset) * 10,
             // Right on ~last instant of the day
             date: calendar.startOfDay(calendar.offset(entry.element, byDays: 1)).addingTimeInterval(-1),
             unit: "unittest"
           ),
-          QuantitySample(
+          LocalQuantitySample(
             value: 100 + Double(entry.offset) * 10,
             date: calendar.startOfDay(entry.element).addingTimeInterval(60 * (Double(entry.offset) + 1)),
             unit: "unittest"
           ),
-          QuantitySample(
+          LocalQuantitySample(
             value: 1000 + Double(entry.offset) * 100,
             date: calendar.startOfDay(entry.element).addingTimeInterval(28800 + 60 * (Double(entry.offset) + 1)),
             unit: "unittest"
@@ -282,12 +282,12 @@ class VitalHealthKitFreeFunctionsTests: XCTestCase {
           )
         ]),
         samples: ActivityPatch.Activity(
-          activeEnergyBurned: makeQuantitySamples(for: sampleDates),
-          basalEnergyBurned: makeQuantitySamples(for: sampleDates),
-          steps: makeQuantitySamples(for: sampleDates),
-          floorsClimbed: makeQuantitySamples(for: sampleDates),
-          distanceWalkingRunning: makeQuantitySamples(for: sampleDates),
-          vo2Max: makeQuantitySamples(for: sampleDates)
+          activeEnergyBurned: makeLocalQuantitySamples(for: sampleDates),
+          basalEnergyBurned: makeLocalQuantitySamples(for: sampleDates),
+          steps: makeLocalQuantitySamples(for: sampleDates),
+          floorsClimbed: makeLocalQuantitySamples(for: sampleDates),
+          distanceWalkingRunning: makeLocalQuantitySamples(for: sampleDates),
+          vo2Max: makeLocalQuantitySamples(for: sampleDates)
         ),
         in: calendar
       )


### PR DESCRIPTION
Change:
* Timeseries API -> Grouped Timeseries API

Rename:
* TimeSeriesDataPoint -> ScalarSample
* BloodPressureDataPoint -> BloodPressureSample
* QuantitySample -> LocalQuantitySample
* BloodPressureSample -> LocalBloodPressureSample

Remove:
* ScalarSample.id
* BloodPressureSample.id
