### PR TITLE
VIT-6623: Catch up with API deprecations Pt.2

### DIFF
--- a/Sources/VitalCore/Calendar/GregorianCalendar.swift
+++ b/Sources/VitalCore/Calendar/GregorianCalendar.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 public struct GregorianCalendar {
-  public static let utc = GregorianCalendar(timeZone: TimeZone(secondsFromGMT: 0)!)
+  public static let utcTimeZone = TimeZone(secondsFromGMT: 0)!
+  public static let utc = GregorianCalendar(timeZone: Self.utcTimeZone)
 
   let base: Calendar
 

--- a/Sources/VitalCore/Core/Client/Data Models/Base Models/LinkCRUD.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Base Models/LinkCRUD.swift
@@ -48,29 +48,64 @@ public struct CreateOAuthProviderResponse: Decodable {
 }
 
 
-public struct CreateEmailProviderRequest: Encodable {
+public struct LinkEmailProviderInput: Encodable {
   public let email: String
   public let region: String?
-  
-  public init(
-    email: String,
-    region: String?
-  ) {
+
+  public init(email: String, region: String? = nil) {
     self.email = email
     self.region = region
   }
 }
 
-public struct CreateEmailProviderResponse: Decodable {
-  public let success: Bool
-  public let redirectUrl: String?
-  
-  public init(
-    success: Bool,
-    redirectUrl: String?
-  ) {
-    self.success = success
-    self.redirectUrl = redirectUrl
+public struct LinkPasswordProviderInput: Encodable {
+  public let username: String
+  public let password: String
+  public let region: String?
+
+  public init(username: String, password: String, region: String? = nil) {
+    self.username = username
+    self.password = password
+    self.region = region
   }
 }
 
+public struct CompletePasswordProviderMFAInput: Encodable {
+  public let mfaCode: String
+
+  public init(mfaCode: String) {
+    self.mfaCode = mfaCode
+  }
+}
+
+public struct LinkResponse: Decodable {
+  public let state: State
+  public let redirectUrl: String?
+  public let error_type: String?
+  public let error: String?
+  public let providerMfa: ProviderMFA?
+
+  public init(state: State, redirectUrl: String?, error_type: String?, error: String?, providerMfa: ProviderMFA?) {
+    self.state = state
+    self.redirectUrl = redirectUrl
+    self.error_type = error_type
+    self.error = error
+    self.providerMfa = providerMfa
+  }
+
+  public enum State: String, RawRepresentable, Decodable {
+    case success
+    case error
+    case pendingProviderMFA = "pending_provider_mfa"
+  }
+
+  public struct ProviderMFA: Decodable {
+    public enum Method: String, RawRepresentable, Decodable {
+      case sms
+      case email
+    }
+
+    public let method: Method
+    public let hint: String
+  }
+}

--- a/Sources/VitalCore/Core/Client/Data Models/Gets/Activity.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Gets/Activity.swift
@@ -10,11 +10,11 @@ public struct ActivityRawResponse: Equatable, Decodable {
 
 public struct ActivitySummary: Equatable, Decodable {
   public var id: UUID
-  public var date: Date
+  public var calendarDate: String
   public var caloriesTotal: Double?
   public var caloriesActive: Double?
   public var steps: Int?
-  public var dailyMovement: Int?
+  public var distance: Double?
   public var low: Double?
   public var medium: Double?
   public var high: Double?

--- a/Sources/VitalCore/Core/Client/Data Models/Gets/Body.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Gets/Body.swift
@@ -10,7 +10,7 @@ public struct BodyRawResponse: Equatable, Decodable {
 
 public struct BodySummary: Equatable, Decodable {
   public var id: UUID
-  public var date: Date
+  public var calendarDate: String
   public var weight: Double?
   public var fat: Double?
   public var source: Source

--- a/Sources/VitalCore/Core/Client/Data Models/Gets/Sleep.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Gets/Sleep.swift
@@ -7,6 +7,7 @@ public struct SleepResponse: Equatable, Decodable {
 public struct SleepSummary: Equatable, Decodable {
   public var id: UUID
   public var source: Source
+  public var calendarDate: String
   public var bedtimeStart: Date
   public var bedtimeStop: Date
   public var timezoneOffset: Int?
@@ -24,14 +25,6 @@ public struct SleepSummary: Equatable, Decodable {
   public var temperatureDelta: Float?
   public var averageHrv: Float?
   public var respiratoryRate: Float?
-  public var sleepStream: SleepStream?
-}
-
-public struct SleepStream: Equatable, Decodable {
-  public var hrv: [TimeseriesSummary]?
-  public var heartrate: [TimeseriesSummary]?
-  public var hypnogram: [TimeseriesSummary]?
-  public var respiratoryRate: [TimeseriesSummary]?
 }
 
 public struct SleepRawResponse: Equatable, Decodable {

--- a/Sources/VitalCore/Core/Client/Data Models/Gets/Timeseries.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Gets/Timeseries.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-public struct TimeseriesSummary: Equatable, Decodable {
-  public var id: Int?
-  public var timestamp: Date
-  public var value: Float
-  public var type: String?
-  public var unit: String?
-}

--- a/Sources/VitalCore/Core/Client/Data Models/Gets/Workout.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Gets/Workout.swift
@@ -10,11 +10,13 @@ public struct WorkoutSummary: Equatable, Decodable {
   public var title: String?
   public var timezoneOffset: Int?
 
+  public var timeStart: Date
+  public var timeEnd: Date
+  public var calendarDate: String
+
   public var averageHr: Int?
   public var maxHr: Int?
   public var distance: Double?
-  public var timeStart: Date
-  public var timeEnd: Date
   public var calories: Double?
   public var sport: Sport
   public var hrZones: [Int]?

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/TaggedPayload.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/TaggedPayload.swift
@@ -5,13 +5,13 @@ public struct TaggedPayload: Encodable {
   public let startDate: Date?
   public let endDate: Date?
   public let timeZone: String
-  public let provider: UserConnection.Slug
+  public let provider: Provider.Slug
   public let data: VitalAnyEncodable
   
   public init(
     stage: Stage = .daily,
     timeZone: TimeZone,
-    provider: UserConnection.Slug = .manual,
+    provider: Provider.Slug = .manual,
     data: VitalAnyEncodable
   ) {
     self.provider = provider

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/UserConnection.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/UserConnection.swift
@@ -1,7 +1,7 @@
 struct ProviderResponse: Equatable, Decodable {
   struct Provider: Equatable, Decodable {
     let name: String
-    let slug: VitalCore.UserConnection.Slug
+    let slug: VitalCore.Provider.Slug
     let logo: String
     let status: VitalCore.UserConnection.Status
     let resourceAvailability: [VitalAPIResource: VitalCore.UserConnection.ResourceAvailability]
@@ -21,7 +21,7 @@ struct ProviderResponse: Equatable, Decodable {
         forKey: ProviderResponse.Provider.CodingKeys.name
       )
       self.slug = try container.decode(
-        VitalCore.UserConnection.Slug.self,
+        VitalCore.Provider.Slug.self,
         forKey: ProviderResponse.Provider.CodingKeys.slug
       )
       self.logo = try container.decode(
@@ -49,7 +49,7 @@ struct ProviderResponse: Equatable, Decodable {
 
 public struct UserConnection: Equatable {
   public let name: String
-  public let slug: Slug
+  public let slug: Provider.Slug
   public let logo: String
   public let status: Status
   public let resourceAvailability: [VitalAPIResource: VitalCore.UserConnection.ResourceAvailability]
@@ -109,6 +109,12 @@ public struct UserConnection: Equatable {
       self.optional = optional
     }
   }
+}
+
+public struct Provider: Equatable {
+  public let name: String
+  public let slug: Slug
+  public let logo: String
 
   public enum Slug: Hashable, Codable, RawRepresentable {
     case beurerBLE

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Endpoints+Extensions.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Endpoints+Extensions.swift
@@ -3,7 +3,7 @@ import Foundation
 func makeBaseQuery(
   startDate: Date,
   endDate: Date?,
-  provider: UserConnection.Slug? = nil
+  provider: Provider.Slug? = nil
 ) -> [(String, String?)] {
   
   let formatter = DateFormatter()

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Summary.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Summary.swift
@@ -19,7 +19,7 @@ public extension VitalClient.Summary {
   func post(
     _ summaryData: SummaryData,
     stage: TaggedPayload.Stage,
-    provider: UserConnection.Slug,
+    provider: Provider.Slug,
     timeZone: TimeZone
   ) async throws -> Void {
     let userId = try await self.client.getUserId()
@@ -43,7 +43,7 @@ public extension VitalClient.Summary {
   func sleepsSummary(
     startDate: Date,
     endDate: Date? = nil,
-    provider: UserConnection.Slug? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [SleepSummary] {
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
@@ -61,7 +61,7 @@ public extension VitalClient.Summary {
   func sleepsRaw(
     startDate: Date,
     endDate: Date? = nil,
-    provider: UserConnection.Slug? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [AnyDecodable] {
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
@@ -75,29 +75,11 @@ public extension VitalClient.Summary {
     
     return result.value.sleep
   }
-  
-  func sleepsSummaryWithStream(
-    startDate: Date,
-    endDate: Date? = nil,
-    provider: UserConnection.Slug? = nil
-  ) async throws -> [SleepSummary] {
-    let userId = try await self.client.getUserId()
-    let configuration = await self.client.configuration.get()
-    
-    let prefix: String = "/\(configuration.apiVersion)/\(self.resource)/"
-    let fullPath = prefix + "sleep/\(userId)/stream"
-    let query = makeBaseQuery(startDate: startDate, endDate: endDate, provider: provider)
-    
-    let request: Request<SleepResponse> = .init(path: fullPath, method: .get, query: query)
-    let result = try await configuration.apiClient.send(request)
-    
-    return result.value.sleep
-  }
-  
+
   func activitySummary(
     startDate: Date,
     endDate: Date? = nil,
-    provider: UserConnection.Slug? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [ActivitySummary] {
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
@@ -115,7 +97,7 @@ public extension VitalClient.Summary {
   func activityRaw(
     startDate: Date,
     endDate: Date? = nil,
-    provider: UserConnection.Slug? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [AnyDecodable] {
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
@@ -133,7 +115,7 @@ public extension VitalClient.Summary {
   func workoutSummary(
     startDate: Date,
     endDate: Date? = nil,
-    provider: UserConnection.Slug? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [WorkoutSummary] {
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
@@ -151,7 +133,7 @@ public extension VitalClient.Summary {
   func workoutRaw(
     startDate: Date,
     endDate: Date? = nil,
-    provider: UserConnection.Slug? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [AnyDecodable] {
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
@@ -169,7 +151,7 @@ public extension VitalClient.Summary {
   func body(
     startDate: Date,
     endDate: Date? = nil,
-    provider: UserConnection.Slug? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [BodySummary] {
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
@@ -187,7 +169,7 @@ public extension VitalClient.Summary {
   func bodyRaw(
     startDate: Date,
     endDate: Date? = nil,
-    provider: UserConnection.Slug? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> [AnyDecodable] {
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
@@ -1,20 +1,9 @@
 import Foundation
 
-public enum ScalarTimeseriesResource {
-  case glucose
-  case heartRate
-  case bloodOxygen
-
-  var toPath: String {
-    switch self {
-      case .heartRate:
-        return "heartrate"
-      case .glucose:
-        return "glucose"
-      case .bloodOxygen:
-        return "blood_oxygen"
-    }
-  }
+public enum ScalarTimeseriesResource: String {
+  case glucose = "glucose"
+  case heartRate = "heartrate"
+  case bloodOxygen = "blood_oxygen"
 }
 
 public extension VitalClient {
@@ -36,7 +25,7 @@ public extension VitalClient.TimeSeries {
   func post(
     _ timeSeriesData: TimeSeriesData,
     stage: TaggedPayload.Stage,
-    provider: UserConnection.Slug,
+    provider: Provider.Slug,
     timeZone: TimeZone
   ) async throws -> Void {
     let userId = try await self.client.getUserId()
@@ -60,15 +49,15 @@ public extension VitalClient.TimeSeries {
     resource: ScalarTimeseriesResource,
     startDate: Date,
     endDate: Date? = nil,
-    provider: UserConnection.Slug? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> GroupedSamplesResponse<ScalarSample> {
 
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
 
     let query = makeBaseQuery(startDate: startDate, endDate: endDate, provider: provider)
-    let path = resource.toPath
-    
+    let path = resource.rawValue
+
     let fullPath = await makePath(for: path, userId: userId)
     
     let request: Request<GroupedSamplesResponse<ScalarSample>> = .init(path: fullPath, method: .get, query: query)
@@ -80,7 +69,7 @@ public extension VitalClient.TimeSeries {
   func getBloodPressure(
     startDate: Date,
     endDate: Date? = nil,
-    provider: UserConnection.Slug? = nil
+    provider: Provider.Slug? = nil
   ) async throws -> GroupedSamplesResponse<BloodPressureSample> {
 
     let userId = try await self.client.getUserId()

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+User.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+User.swift
@@ -15,7 +15,7 @@ public extension VitalClient {
 
 public extension VitalClient.User {
 
-  func userConnectedSources() async throws -> [UserConnection] {
+  func userConnections() async throws -> [UserConnection] {
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
 
@@ -36,6 +36,7 @@ public extension VitalClient.User {
     return providers
   }
 
+  @_spi(VitalSDKInternals)
   func sdkStateSync(body: UserSDKSyncStateBody) async throws -> UserSDKSyncStateResponse {
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
@@ -77,8 +78,8 @@ public extension VitalClient.User {
       setUserIdOnSuccess: setUserIdOnSuccess
     )
   }
-  
-  func deregisterProvider(provider: UserConnection.Slug) async throws -> Void {
+
+  func deregisterProvider(provider: Provider.Slug) async throws -> Void {
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
     

--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -555,7 +555,7 @@ public let health_secureStorageKey: String = "health_secureStorageKey"
     shared._setUserId(newUserId)
   }
   
-  public func isUserConnected(to provider: UserConnection.Slug) async throws -> Bool {
+  public func isUserConnected(to provider: Provider.Slug) async throws -> Bool {
     let userId = try await getUserId()
     let storage = self.storage
     
@@ -563,11 +563,11 @@ public let health_secureStorageKey: String = "health_secureStorageKey"
       return true
     }
     
-    let connectedSources: [UserConnection] = try await self.user.userConnectedSources()
+    let connectedSources: [UserConnection] = try await self.user.userConnections()
     return connectedSources.contains { $0.slug == provider }
   }
   
-  public func checkConnectedSource(for provider: UserConnection.Slug) async throws {
+  public func checkConnectedSource(for provider: Provider.Slug) async throws {
     let userId = try await getUserId()
     let storage = self.storage
     

--- a/Sources/VitalCore/Core/Storage/VitalCoreStorage.swift
+++ b/Sources/VitalCore/Core/Storage/VitalCoreStorage.swift
@@ -4,8 +4,8 @@ import Foundation
 private let heartRateFlagOldKey = "vitals(VitalCore.VitalResource.Vitals.hearthRate)"
 
 public struct VitalBackStorage {
-  public var isConnectedSourceStored: (String, UserConnection.Slug) -> Bool
-  public var storeConnectedSource: (String, UserConnection.Slug) -> Void
+  public var isConnectedSourceStored: (String, Provider.Slug) -> Bool
+  public var storeConnectedSource: (String, Provider.Slug) -> Void
   
   public var flagResource: (VitalResource) -> Void
   public var isResourceFlagged: (VitalResource) -> Bool
@@ -29,7 +29,7 @@ public struct VitalBackStorage {
     let defaultValue: [String: String] = [:]
     userDefaults.register(defaults: defaultValue)
     
-    let generateKey: (String, UserConnection.Slug) -> String = { userId, provider in
+    let generateKey: (String, Provider.Slug) -> String = { userId, provider in
       return "\(userId)-\(provider.rawValue)"
     }
     
@@ -76,7 +76,7 @@ public struct VitalBackStorage {
 
     var dateStorage: [String: Double] = [:]
 
-    let generateKey: (String, UserConnection.Slug) -> String = { userId, provider in
+    let generateKey: (String, Provider.Slug) -> String = { userId, provider in
       return "\(userId)-\(provider.rawValue)"
     }
     
@@ -117,11 +117,11 @@ public class VitalCoreStorage {
     self.storage = storage
   }
   
-  func storeConnectedSource(for userId: String, with provider: UserConnection.Slug) {
+  func storeConnectedSource(for userId: String, with provider: Provider.Slug) {
     storage.storeConnectedSource(userId, provider)
   }
   
-  func isConnectedSourceStored(for userId: String, with provider: UserConnection.Slug) -> Bool {
+  func isConnectedSourceStored(for userId: String, with provider: Provider.Slug) -> Bool {
     return storage.isConnectedSourceStored(userId, provider)
   }
   

--- a/Sources/VitalDevices/DeviceManager+Brands.swift
+++ b/Sources/VitalDevices/DeviceManager+Brands.swift
@@ -142,7 +142,7 @@ public extension DevicesManager {
     ]
   }
   
-  static func provider(for brand: Brand) -> UserConnection.Slug {
+  static func provider(for brand: Brand) -> Provider.Slug {
     switch brand {
       case .omron:
         return .omronBLE

--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -1,5 +1,5 @@
 import HealthKit
-import VitalCore
+@_spi(VitalSDKInternals) import VitalCore
 
 struct RemappedVitalResource: Hashable {
   let wrapped: VitalResource
@@ -207,8 +207,8 @@ extension VitalHealthKitStore {
 }
 
 struct VitalClientProtocol {
-  var post: (ProcessedResourceData, TaggedPayload.Stage, UserConnection.Slug, TimeZone) async throws -> Void
-  var checkConnectedSource: (UserConnection.Slug) async throws -> Void
+  var post: (ProcessedResourceData, TaggedPayload.Stage, Provider.Slug, TimeZone) async throws -> Void
+  var checkConnectedSource: (Provider.Slug) async throws -> Void
   var sdkStateSync: (UserSDKSyncStateBody) async throws -> UserSDKSyncStateResponse
 }
 

--- a/Tests/VitalCoreTests/ProviderTests.swift
+++ b/Tests/VitalCoreTests/ProviderTests.swift
@@ -6,7 +6,7 @@ import Mocker
 class ProviderTests: XCTestCase {
   func test_provider_slug_encoding() throws {
     let encoder = JSONEncoder()
-    let slug = UserConnection.Slug.appleHealthKit
+    let slug = Provider.Slug.appleHealthKit
     let data = try encoder.encode(slug)
 
     XCTAssertEqual(data, "\"\(slug.rawValue)\"".data(using: .utf8))
@@ -14,15 +14,15 @@ class ProviderTests: XCTestCase {
 
   func test_provider_slug_decoding() throws {
     let decoder = JSONDecoder()
-    let slug = UserConnection.Slug.appleHealthKit
+    let slug = Provider.Slug.appleHealthKit
     let data = try XCTUnwrap("\"\(slug.rawValue)\"".data(using: .utf8))
 
-    XCTAssertEqual(slug, try decoder.decode(UserConnection.Slug.self, from: data))
+    XCTAssertEqual(slug, try decoder.decode(Provider.Slug.self, from: data))
   }
 
   func test_provider_slug_encoding_unknown_value() throws {
     let encoder = JSONEncoder()
-    let slug = UserConnection.Slug.unknown("whomst")
+    let slug = Provider.Slug.unknown("whomst")
     let data = try encoder.encode(slug)
 
     XCTAssertEqual(data, "\"\(slug.rawValue)\"".data(using: .utf8))
@@ -30,9 +30,9 @@ class ProviderTests: XCTestCase {
 
   func test_provider_slug_decoding_unknown_value() throws {
     let decoder = JSONDecoder()
-    let slug = UserConnection.Slug.unknown("whomst")
+    let slug = Provider.Slug.unknown("whomst")
     let data = try XCTUnwrap("\"\(slug.rawValue)\"".data(using: .utf8))
 
-    XCTAssertEqual(slug, try decoder.decode(UserConnection.Slug.self, from: data))
+    XCTAssertEqual(slug, try decoder.decode(Provider.Slug.self, from: data))
   }
 }

--- a/Tests/VitalCoreTests/VitalClientTests.swift
+++ b/Tests/VitalCoreTests/VitalClientTests.swift
@@ -7,7 +7,7 @@ let environment = Environment.sandbox(.us)
 let userId = UUID().uuidString
 let apiKey = UUID().uuidString
 let apiVersion = "2.0"
-let provider = UserConnection.Slug.strava
+let provider = Provider.Slug.strava
 
 class VitalClientTests: XCTestCase {
   let storage = VitalCoreStorage(storage: .debug)


### PR DESCRIPTION
Changes:
* Standard Link API response

Rename:
* UserConnection.Slug -> Provider.Slug

Addition:
* `calendar_date` on summaries
* Link Password Provider & Complete Password Provider MFA

Removal:
* `date` from body and activity
* `daily_movement` from activity
* Sleep Stream endpoint
