### PR TITLE
VIT-6623: Catch up with API deprecations Pt.3

### DIFF
--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Endpoints+Extensions.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Endpoints+Extensions.swift
@@ -3,7 +3,8 @@ import Foundation
 func makeBaseQuery(
   startDate: Date,
   endDate: Date?,
-  provider: Provider.Slug? = nil
+  provider: Provider.Slug? = nil,
+  cursor: String? = nil
 ) -> [(String, String?)] {
   
   let formatter = DateFormatter()
@@ -20,6 +21,10 @@ func makeBaseQuery(
   if let provider = provider {
     query.append(("provider", provider.rawValue))
   }
-  
+
+  if let cursor = cursor {
+    query.append(("cursor", cursor))
+  }
+
   return query
 }

--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
@@ -49,13 +49,14 @@ public extension VitalClient.TimeSeries {
     resource: ScalarTimeseriesResource,
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider.Slug? = nil
+    provider: Provider.Slug? = nil,
+    cursor: String? = nil
   ) async throws -> GroupedSamplesResponse<ScalarSample> {
 
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
 
-    let query = makeBaseQuery(startDate: startDate, endDate: endDate, provider: provider)
+    let query = makeBaseQuery(startDate: startDate, endDate: endDate, provider: provider, cursor: cursor)
     let path = resource.rawValue
 
     let fullPath = await makePath(for: path, userId: userId)
@@ -69,15 +70,16 @@ public extension VitalClient.TimeSeries {
   func getBloodPressure(
     startDate: Date,
     endDate: Date? = nil,
-    provider: Provider.Slug? = nil
+    provider: Provider.Slug? = nil,
+    cursor: String? = nil
   ) async throws -> GroupedSamplesResponse<BloodPressureSample> {
 
     let userId = try await self.client.getUserId()
     let configuration = await self.client.configuration.get()
 
     let path = await makePath(for: "blood_pressure", userId: userId)
-    let query = makeBaseQuery(startDate: startDate, endDate: endDate, provider: provider)
-    
+    let query = makeBaseQuery(startDate: startDate, endDate: endDate, provider: provider, cursor: cursor)
+
     let request: Request<GroupedSamplesResponse<BloodPressureSample>> = .init(path: path, method: .get, query: query)
     let response = try await configuration.apiClient.send(request)
     


### PR DESCRIPTION
Timeseries methods missing support for the `cursor` parameter