### PR TITLE
VIT-6644: Fix VitalClient.status false negative when keychain is inaccessible

### DIFF
--- a/Examples/iOS/Root.swift
+++ b/Examples/iOS/Root.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import VitalCore
 import ComposableArchitecture
 import VitalHealthKit
+import os
 
 @main
 struct ExampleApp: App {
@@ -11,7 +12,6 @@ struct ExampleApp: App {
       didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
     ) -> Bool {
       VitalLogger.stdOutEnabled = true
-
       VitalHealthKitClient.automaticConfiguration()
       return true
     }

--- a/Sources/VitalCore/Core/Storage/VitalGistStorage.swift
+++ b/Sources/VitalCore/Core/Storage/VitalGistStorage.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+internal protocol GistKey<T> {
+  associatedtype T: Codable
+  static var identifier: String { get }
+}
+
+/// GistStorage stores data to the Application Support directory with `.noFileProtection`.
+/// This ensures that the gist data would remain accessible before device first unlock.
+/// 
+/// Certain SDK queries (e.g., `VitalClient.status`) are backed by Gist Storage, since the host app
+/// may be pre-warmed in iOS 15+ and therefore may unintentionally query the SDK during this post reboot to device
+/// first unlock time window.
+internal final class VitalGistStorage: @unchecked Sendable {
+  private static let directoryURL = {
+    let applicationSupport: URL
+
+    if #available(iOS 16.0, *) {
+      applicationSupport = URL.applicationSupportDirectory
+    } else {
+      applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    }
+
+    return applicationSupport.appendingPathComponent("io.tryvital.VitalCore", isDirectory: true)
+  }()
+
+  private static func fileURL(forKey key: String) -> URL {
+    Self.directoryURL.appendingPathComponent("\(key).json", isDirectory: false)
+  }
+
+  private var state: [ObjectIdentifier: State] = [:]
+  private let lock = NSLock()
+
+  static let shared = VitalGistStorage()
+
+  func get<Key: GistKey>(_ key: Key.Type) -> Key.T? {
+    let typeKey = ObjectIdentifier(key)
+
+    do {
+      return try lock.withLock { () -> Key.T? in
+        switch self.state[typeKey, default: .uninitialized] {
+        case let .hasGist(gist):
+          return (gist as! Key.T)
+
+        case .noGist:
+          return nil
+
+        case .uninitialized:
+          do {
+            // Hydrate gist from disk
+            let data = try Data(contentsOf: Self.fileURL(forKey: key.identifier))
+            let gist = try JSONDecoder().decode(Key.T.self, from: data)
+            self.state[typeKey] = .hasGist(gist)
+            return gist
+
+          } catch let error as CocoaError {
+            if error.code == .fileReadNoSuchFile {
+              self.state[typeKey] = .noGist
+              return nil
+            }
+
+            throw error
+          }
+        }
+      }
+
+    } catch let error {
+      VitalLogger.core.error("failed to load \(key.identifier): \(error)", source: "VitalGistStorage")
+      return nil
+    }
+  }
+
+  func set<Key: GistKey>(_ newValue: VitalJWTAuthRecordGist?, for key: Key.Type) throws {
+    let typeKey = ObjectIdentifier(key)
+    let url = Self.fileURL(forKey: key.identifier)
+
+    try lock.withLock {
+      if let newValue = newValue {
+        let directoryUrl = Self.directoryURL
+        if !FileManager.default.fileExists(atPath: directoryUrl.absoluteString) {
+          try FileManager.default.createDirectory(at: Self.directoryURL, withIntermediateDirectories: true)
+        }
+
+        let data = try JSONEncoder().encode(newValue)
+        // noFileProtection to ensure that the gist is accessible even before first unlock.
+        try data.write(to: url, options: [.atomic, .noFileProtection])
+        self.state[typeKey] = .hasGist(newValue)
+
+      } else {
+        if FileManager.default.fileExists(atPath: url.absoluteString) {
+          try FileManager.default.removeItem(at: url)
+        }
+        self.state[typeKey] = .noGist
+      }
+    }
+  }
+
+  enum State {
+    case hasGist(Any)
+    case noGist
+    case uninitialized
+  }
+}

--- a/Sources/VitalCore/Core/Storage/VitalSecureStorage.swift
+++ b/Sources/VitalCore/Core/Storage/VitalSecureStorage.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct Keychain {
   var set: (Data, String) -> Void
-  var get: (String) -> Data?
+  var get: (String) throws -> Data?
   var clean: (String) -> Void
 
   public static var live: Keychain {
@@ -11,7 +11,7 @@ public struct Keychain {
     return .init { data, key in
       keychain.set(data, forKey: key, withAccess: .accessibleAfterFirstUnlock)
     } get: { key in
-      keychain.getData(key)
+      try keychain.getData(key)
     } clean: { key in
       keychain.delete(key)
     }
@@ -48,7 +48,7 @@ public class VitalSecureStorage {
   }
   
   public func get<T: Decodable>(key: String) throws -> T? {
-    guard let value: Data = keychain.get(key) else {
+    guard let value: Data = try keychain.get(key) else {
       return nil
     }
     


### PR DESCRIPTION
We currently store `VitalJWTAuthRecord` in Keychain.

It appears that our host apps could be woken up by iOS before the iOS Keychain is accessible after first unlock.

We had run into issues during this time window (#114) where we treat "keychain inaccessible" as no record, and therefore `VitalClient.status` reports a signed-out state. This is despite a valid `VitalJWTAuthRecord` sitting in the iOS Keychain, just not being accessible due to timing with OS data protection.

While #114 patched the issue by restructuring the [Core SDK SignOut -> Child SDK Reset] broadcast not to rely on `VitalClient.status`, it does not resolve the issue of both `VitalClient.status` and `VitalClient.currentUserId` reporting a false negative (signed-out state) during this time window.

This PR tackles this false negative, where:

1. We store a "gist" of the `VitalJWTAuthRecord` in the filesystem directly.
    * The gist excludes all token secrets 
    * We explicitly request the OS not to apply file protection to this file. This ensures the gist is accessible even before first device unlock.

2. The gist is updated whenever `VitalJWTAuthRecord` is updated.
   * For SDK upgrades from older version, the gist would not exist on first app launch. We would fallback to backfill the gist from the keychain record in this case.

4. `VitalClient.status` and `VitalClient.currentUserId` are now backed by the gist, rather than the keychain record. This eliminates the false negatives.

This PR also modifies our vendored copy of KeychainAccess, so it does not report the `errSecInteractionNotAllowed` error (keychain inaccessible) as `nil`, i.e., the same as no record.

For inspiration, a related blogpost on this issue: https://sourcediving.com/solving-mysterious-logout-issues-on-ios-15-8b818c089466