### PR TITLE
VIT-6646: Device SDK auto-posting samples

### DIFF
--- a/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
+++ b/Sources/VitalCore/Core/Client/Endpoints/VitalClient+Timeseries.swift
@@ -22,6 +22,7 @@ public extension VitalClient {
 }
 
 public extension VitalClient.TimeSeries {
+  @_spi(VitalSDKInternals)
   func post(
     _ timeSeriesData: TimeSeriesData,
     stage: TaggedPayload.Stage,

--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -575,6 +575,7 @@ public let health_secureStorageKey: String = "health_secureStorageKey"
     return connectedSources.contains { $0.slug == provider }
   }
   
+  @_spi(VitalSDKInternals)
   public func checkConnectedSource(for provider: Provider.Slug) async throws {
     let userId = try await getUserId()
     let storage = self.storage

--- a/Sources/VitalCore/Core/Logs/VitalLogger.swift
+++ b/Sources/VitalCore/Core/Logs/VitalLogger.swift
@@ -35,6 +35,7 @@ public enum VitalLogger {
   }
 
   public private(set) static var core = VitalLogging.Logger(label: Category.core.rawValue, factory: Self.logHandlerFactory)
+  public private(set) static var devices = VitalLogging.Logger(label: Category.devices.rawValue, factory: Self.logHandlerFactory)
   public private(set) static var requests = VitalLogging.Logger(label: Category.requests.rawValue, factory: Self.logHandlerFactory)
   public private(set) static var healthKit = VitalLogging.Logger(label: Category.healthKit.rawValue, factory: Self.logHandlerFactory)
 
@@ -42,6 +43,7 @@ public enum VitalLogger {
     case core
     case requests
     case healthKit
+    case devices
     case requestBody
   }
 

--- a/Sources/VitalDevices/DeviceReading/BloodPressureReader1810.swift
+++ b/Sources/VitalDevices/DeviceReading/BloodPressureReader1810.swift
@@ -16,7 +16,10 @@ class BloodPressureReader1810: GATTMeterWithNoRACP<LocalBloodPressureSample>, Bl
       serviceID: CBUUID(string: "1810".fullUUID),
       // Blood Pressure Measurement characteristic
       measurementCharacteristicID: CBUUID(string: "2A35".fullUUID),
-      parser: toBloodPressureReading(data:)
+      parser: toBloodPressureReading(data:),
+      didReceiveAll: { scannedDevice, samples in
+        postBloodPressure(scannedDevice.deviceModel.brand.providerSlug, samples: samples)
+      }
     )
   }
 }

--- a/Sources/VitalDevices/DeviceReading/GlucoseMeter1808.swift
+++ b/Sources/VitalDevices/DeviceReading/GlucoseMeter1808.swift
@@ -16,7 +16,10 @@ class GlucoseMeter1808: GATTMeter<LocalQuantitySample>, GlucoseMeterReadable {
       queue: queue,
       serviceID: CBUUID(string: "1808".fullUUID),
       measurementCharacteristicID: CBUUID(string: "2A18".fullUUID),
-      parser: toGlucoseReading(data:)
+      parser: toGlucoseReading(data:),
+      didReceiveAll: { scannedDevice, samples in
+        postGlucose(scannedDevice.deviceModel.brand.providerSlug, samples: samples)
+      }
     )
   }
 }

--- a/Sources/VitalDevices/DeviceReading/Libre1Reader.swift
+++ b/Sources/VitalDevices/DeviceReading/Libre1Reader.swift
@@ -39,6 +39,8 @@ public class Libre1Reader {
     let samples = payload.1.map(LocalQuantitySample.init)
     let sensor = Libre1Sensor.init(sensor: payload.0)
     
+    postGlucose(.libreBLE, samples: samples)
+
     return Libre1Read(samples: samples, sensor: sensor)
   }
 }

--- a/Sources/VitalDevices/DeviceReading/VerioGlucoseMeter.swift
+++ b/Sources/VitalDevices/DeviceReading/VerioGlucoseMeter.swift
@@ -102,6 +102,9 @@ internal class VerioGlucoseMeter: GlucoseMeterReadable {
         .merge(with: output.collect())
         .handleEvents(
           receiveSubscription: { _ in incomingData.connect().store(in: &cancellables) },
+          receiveOutput: { samples in
+            postGlucose(.oneTouchBLE, samples: samples)
+          },
           receiveCompletion: { _ in cancellables.forEach { $0.cancel() } },
           receiveCancel: { cancellables.forEach { $0.cancel() } }
         )

--- a/Sources/VitalDevices/Integration/PostSamples.swift
+++ b/Sources/VitalDevices/Integration/PostSamples.swift
@@ -1,0 +1,57 @@
+@_spi(VitalSDKInternals) import VitalCore
+
+
+internal func postGlucose(_ provider: Provider.Slug, samples: [LocalQuantitySample]) {
+  Task {
+    do {
+      try await postGlucoseImpl(provider, samples: samples)
+      VitalLogger.devices.info("posted \(samples.count) glucose for \(provider)", source: "PostSamples")
+
+    } catch let error {
+      VitalLogger.devices.error("failed to post \(samples.count) glucose for \(provider): \(error)", source: "PostSamples")
+    }
+  }
+}
+
+
+internal func postBloodPressure(_ provider: Provider.Slug, samples: [LocalBloodPressureSample]) {
+  Task {
+    do {
+      try await postBloodPressureImpl(provider, samples: samples)
+      VitalLogger.devices.info("posted \(samples.count) BP for \(provider)", source: "PostSamples")
+
+    } catch let error {
+      VitalLogger.devices.error("failed to post \(samples.count) BP for \(provider): \(error)", source: "PostSamples")
+    }
+  }
+}
+
+
+private func postGlucoseImpl(_ provider: Provider.Slug, samples: [LocalQuantitySample]) async throws {
+  guard VitalClient.status.contains(.signedIn) else {
+    return
+  }
+
+  try await VitalClient.shared.checkConnectedSource(for: provider)
+  try await VitalClient.shared.timeSeries.post(
+    .glucose(samples),
+    stage: .daily,
+    provider: provider,
+    timeZone: .current
+  )
+}
+
+
+private func postBloodPressureImpl(_ provider: Provider.Slug, samples: [LocalBloodPressureSample]) async throws {
+  guard VitalClient.status.contains(.signedIn) else {
+    return
+  }
+
+  try await VitalClient.shared.checkConnectedSource(for: provider)
+  try await VitalClient.shared.timeSeries.post(
+    .bloodPressure(samples),
+    stage: .daily,
+    provider: provider,
+    timeZone: .current
+  )
+}

--- a/Sources/VitalDevices/Integration/PostSamples.swift
+++ b/Sources/VitalDevices/Integration/PostSamples.swift
@@ -2,6 +2,8 @@
 
 
 internal func postGlucose(_ provider: Provider.Slug, samples: [LocalQuantitySample]) {
+  guard !samples.isEmpty else { return }
+
   Task {
     do {
       try await postGlucoseImpl(provider, samples: samples)
@@ -15,6 +17,8 @@ internal func postGlucose(_ provider: Provider.Slug, samples: [LocalQuantitySamp
 
 
 internal func postBloodPressure(_ provider: Provider.Slug, samples: [LocalBloodPressureSample]) {
+  guard !samples.isEmpty else { return }
+
   Task {
     do {
       try await postBloodPressureImpl(provider, samples: samples)

--- a/Sources/VitalDevices/Models/Brand.swift
+++ b/Sources/VitalDevices/Models/Brand.swift
@@ -1,3 +1,5 @@
+import VitalCore
+
 public enum Brand: String, Encodable, Equatable {
   case omron
   case accuChek
@@ -20,6 +22,23 @@ public enum Brand: String, Encodable, Equatable {
         return "FreeStyle Libre"
       case .oneTouch:
         return "OneTouch"
+    }
+  }
+
+  internal var providerSlug: Provider.Slug {
+    switch self {
+    case .contour:
+      return .contourBLE
+    case .omron:
+      return .omronBLE
+    case .accuChek:
+      return .accuchekBLE
+    case .beurer:
+      return .beurerBLE
+    case .libre:
+      return .libreBLE
+    case .oneTouch:
+      return .oneTouchBLE
     }
   }
 }


### PR DESCRIPTION
Mark timeseries POST methods as `@_spi(VitalSDKInternals)`.

Mark `checkConnectedSource` as `@_spi(VitalSDKInternals)`.

Devices SDK would now try to auto-post glucose and blood pressure samples after reading them, if the Core SDK has signed-in with a user.