### PR TITLE
VIT-6662: Handle the Keychain errSecItemNotFound error

### DIFF
--- a/Sources/VitalCore/Keychain/Source/KeychainSwiftDistrib.swift
+++ b/Sources/VitalCore/Keychain/Source/KeychainSwiftDistrib.swift
@@ -217,6 +217,10 @@ class KeychainSwift {
       return result as! Data?
     }
 
+    if lastResultCode == errSecItemNotFound {
+      return nil
+    }
+
     if lastResultCode == errSecInteractionNotAllowed {
       throw VitalKeychainError.interactionNotAllowed
     }


### PR DESCRIPTION
#145 changed our Keychain fetch logic to handle all errors explicitly, rather than lumping all errors & no data scenarios into an overloaded `nil`.

This PR backfills the missing handling of the expected `errSecItemNotFound` error.