### PR TITLE
VIT-6663: iOS: Try to proactively create connected source on successful Ask

### DIFF
--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -578,12 +578,9 @@ public let health_secureStorageKey: String = "health_secureStorageKey"
   @_spi(VitalSDKInternals)
   public func checkConnectedSource(for provider: Provider.Slug) async throws {
     let userId = try await getUserId()
+    try await self.link.createConnectedSource(userId, provider: provider)
+
     let storage = self.storage
-    
-    if try await isUserConnected(to: provider) == false {
-      try await self.link.createConnectedSource(userId, provider: provider)
-    }
-    
     storage.storeConnectedSource(for: userId, with: provider)
   }
 

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -674,6 +674,14 @@ extension VitalHealthKitClient {
     do {
       try await store.requestReadWriteAuthorization(readResources, writeResource)
 
+      // We have gone through Ask successfully. Check if a connected source has been created.
+      do {
+        try await VitalClient.shared.checkConnectedSource(for: .appleHealthKit)
+
+      } catch let error {
+        VitalLogger.healthKit.info("proactive CS creation failed; error = \(error)", source: "Ask")
+      }
+
       if configuration.isNil() == false {
         let configuration = await configuration.get()
         


### PR DESCRIPTION
Proactively try to create a connected source, after the user has gone through the HealthKit permission flow successfully (i.e. did not cancel the prompt).

Also remove the `checkConnectedSource` caching (a persistent flag tracking if the CS has been created):
* In the HealthKit sync process, we would call this as part of the LocalSyncState revalidation logic, so it is already covered by the same 4-hour TTL.
* In Devices SDK, the reading happens somewhat sparingly in absence of BLE background scanning and auto-send support. So it is fine to have it calling the API without caching.