### PR TITLE
VIT-6992: Protect foreground sync work with UIKit background task

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Models/BackgroundDeliveryPayload.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/BackgroundDeliveryPayload.swift
@@ -1,8 +1,10 @@
 import HealthKit
+import UIKit
 
 struct BackgroundDeliveryPayload {
   let sampleTypes: Set<HKSampleType>
   let completion: (Completion) -> Void
+  let appState: UIApplication.State
 
   enum Completion {
     case cancelled


### PR DESCRIPTION
Whenever we spawn sync work in foregorund, protect them with a UIKit background task.

This ensures that they have a better chance to run to completion, should the user decide to background the app at any time.