### PR TITLE
VIT-7052: Remove embedded timeseries from local read()

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -8,11 +8,9 @@ struct RemappedVitalResource: Hashable {
 
 struct ReadOptions {
   var perDeviceActivityTS: Bool = false
-  var embedTimeseries: Bool = false
 
-  internal init(perDeviceActivityTS: Bool = false, embedTimeseries: Bool = false) {
+  internal init(perDeviceActivityTS: Bool = false) {
     self.perDeviceActivityTS = perDeviceActivityTS
-    self.embedTimeseries = embedTimeseries
   }
 }
 

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -583,42 +583,6 @@ func handleSleep(
       var respiratoryRate: [LocalQuantitySample] = []
 
       let fromSameSourceRevision = NSPredicate(format: "%K == %@", HKPredicateKeyPathSourceRevision, sourceRevision)
-
-      if options.embedTimeseries {
-        heartRate = try await querySample(
-          healthKitStore: healthKitStore,
-          type: .quantityType(forIdentifier: .heartRate)!,
-          sampleClass: HKQuantitySample.self,
-          unit: QuantityUnit(.heartRate),
-          startDate: sleep.startDate,
-          endDate: sleep.endDate,
-          extraPredicates: [fromSameSourceRevision],
-          transform: LocalQuantitySample.init
-        )
-
-        hearRateVariability = try await querySample(
-          healthKitStore: healthKitStore,
-          type: .quantityType(forIdentifier: .heartRateVariabilitySDNN)!,
-          sampleClass: HKQuantitySample.self,
-          unit: QuantityUnit(.heartRateVariabilitySDNN),
-          startDate: sleep.startDate,
-          endDate: sleep.endDate,
-          extraPredicates: [fromSameSourceRevision],
-          transform: LocalQuantitySample.init
-        )
-
-        respiratoryRate = try await querySample(
-          healthKitStore: healthKitStore,
-          type: .quantityType(forIdentifier: .respiratoryRate)!,
-          sampleClass: HKQuantitySample.self,
-          unit: QuantityUnit(.respiratoryRate),
-          startDate: sleep.startDate,
-          endDate: sleep.endDate,
-          extraPredicates: [fromSameSourceRevision],
-          transform: LocalQuantitySample.init
-        )
-      }
-
       let wristTemperature: [LocalQuantitySample]
 
       if #available(iOS 16.0, *) {
@@ -848,31 +812,6 @@ func handleWorkouts(
     }
 
     try await computeStatistics(&patch)
-
-    if options.embedTimeseries {
-      patch.heartRate = try await querySample(
-        healthKitStore: healthKitStore,
-        type: .quantityType(forIdentifier: .heartRate)!,
-        sampleClass: HKQuantitySample.self,
-        unit: QuantityUnit(.heartRate),
-        startDate: workout.startDate,
-        endDate: workout.endDate,
-        extraPredicates: predicates.wrapped,
-        transform: LocalQuantitySample.init
-      )
-
-      patch.respiratoryRate = try await querySample(
-        healthKitStore: healthKitStore,
-        type: .quantityType(forIdentifier: .respiratoryRate)!,
-        sampleClass: HKQuantitySample.self,
-        unit: QuantityUnit(.respiratoryRate),
-        startDate: workout.startDate,
-        endDate: workout.endDate,
-        extraPredicates: predicates.wrapped,
-        transform: LocalQuantitySample.init
-      )
-    }
-
     copies.append(patch)
   }
   

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -1147,7 +1147,7 @@ extension VitalHealthKitClient {
       healthKitStore:  HKHealthStore(),
       vitalStorage: VitalHealthKitStorage(storage: .debug),
       instruction: SyncInstruction(stage: .daily, query: startDate ..< endDate),
-      options: ReadOptions(embedTimeseries: true)
+      options: ReadOptions()
     )
 
     return data


### PR DESCRIPTION
Reading individual HKSample off a high-frequency timeseries is a painfully slow process — as compared to using HKStatisticalCollectionQuery — due to the XPC overhead. 

Remove the embedded timeseries data from the local `read()`, since this ain't going to be an tolerable performance for data visualization / UI use case.