### PR TITLE
VIT-7076: Buffer, dedup and batch execute background delivery callouts

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Models/BackgroundDeliveryPayload.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/BackgroundDeliveryPayload.swift
@@ -18,10 +18,9 @@ public enum SyncContextTag: Int, Codable {
 struct BackgroundDeliveryPayload: CustomStringConvertible {
   let resources: [RemappedVitalResource]
   let completion: (Completion) -> Void
-  let tags: Set<SyncContextTag>
 
   var description: String {
-    "\(resources.map(\.wrapped.logDescription).joined(separator: ",")) \(tags.map(String.init(describing:)).joined(separator: ","))"
+    "\(resources.map(\.wrapped.logDescription).joined(separator: ",")))"
   }
 
   enum Completion {

--- a/Sources/VitalHealthKit/UI/ForEachVitalResource.swift
+++ b/Sources/VitalHealthKit/UI/ForEachVitalResource.swift
@@ -61,12 +61,13 @@ public struct ForEachVitalResource: View {
         HStack {
           if let sync = resource.latestSync {
             icon(for: sync.lastStatus)
+              .frame(width: 22, height: 22)
           }
 
           VStack(alignment: .leading) {
             Text("\(key.rawValue)")
             if let tags = resource.latestSync?.tags {
-              Text(verbatim: "\(tags.map(String.init(describing:)).joined(separator: ", "))")
+              Text(verbatim: "\(tags.map(String.init(describing:)).sorted().joined(separator: ", "))")
                 .foregroundColor(Color.secondary)
                 .font(Font.subheadline)
             }
@@ -201,6 +202,7 @@ private struct ResourceProgressDetailView: View {
             } label: {
               HStack(alignment: .center) {
                 icon(for: sync.lastStatus)
+                  .frame(width: 22, height: 22)
 
                 VStack(alignment: .leading) {
                   if sync.lastStatus.isInProgress {


### PR DESCRIPTION
iOS does not seem to like high CPU usage in background. Syncing multiple resources concurrently seems to be leading to our host app process being frozen.

Change it so that:

1. We now only sync concurrently in foreground.
2. In background, we sync resources **serially** with batching and prioritisation.
    * Callouts made within a 16ms window are batched up.
    * Within each batch, notified resources are deduplicated, are sorted by their priority, and are then scheduled for execution serially.