### PR TITLE
VIT-7406: iOS: Lower priority resource is stuck when higher priority resource has errored

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -472,7 +472,9 @@ extension VitalHealthKitClient {
           return true
         }
         // OR has no sync attempt
-        return resourceProgress.syncs.isEmpty
+        // OR has errored
+        let lastStatus = resourceProgress.latestSync?.lastStatus
+        return lastStatus == nil || lastStatus == .error || lastStatus == .cancelled || lastStatus == .timedOut
       }
 
       // Rescue these resources


### PR DESCRIPTION
Some higher priority resource might have errored, cancelled or timed out on their historical stage sync. Then they are stuck in said states, since there is no new data written to HealthKit to trigger a background delivery.

This can in turn block the lower priority resources from syncing, as they are stuck in the _deprioritized_ state due to higher priority resources not having all completed their historical stage.


--

This PR updates the `scheduleUnnotifiedResourceRescue` routine — which runs shortly after app launch to start sync attempts on eligible resources to ensure forward progress for all. 

* The routine has been starting sync on resources that has no sync attempt.
* This PR expands criteria to app launch on any last errored, cancelled, timed out resources, so we "rescue" them from being stuck.