### PR TITLE
Expose HealthKit requirements for VitalResource

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
@@ -28,26 +28,26 @@ import VitalCore
 /// * `VitalResource.heartrate` is the primary resource for `HKQuantityType(.heartRate)`.
 /// * Activity, workouts and sleeps all need _supplementary_ heartrate permission for statistics, but can function without it.
 ///   So they list `HKQuantityType(.heartRate)` as their `supplementary` types.
-struct HealthKitObjectTypeRequirements {
+public struct HealthKitObjectTypeRequirements {
   /// The required set of HKObjectTypes of a `VitalResource`.
   ///
   /// This must not change once the `VitalResource` is introduced, especially if
   /// the `VitalResource` is a fully computed resource like `activity`.
-  let required: Set<HKObjectType>
+  public let required: Set<HKObjectType>
 
   /// An optional set of HKObjectTypes of a `VitalResource`.
   /// New types can be added or removed from this list.
-  let optional: Set<HKObjectType>
+  public let optional: Set<HKObjectType>
 
   /// An "supplementary" set of HKObjectTypes of a `VitalResource`.
   /// New types can be added or removed from this list.
-  let supplementary: Set<HKObjectType>
+  public let supplementary: Set<HKObjectType>
 
-  var isIndividualType: Bool {
+  public var isIndividualType: Bool {
     required.count == 1 && optional.isEmpty && supplementary.isEmpty
   }
 
-  func isResourceActive(_ query: (HKObjectType) -> Bool) -> Bool {
+  public func isResourceActive(_ query: (HKObjectType) -> Bool) -> Bool {
     if self.required.isEmpty {
       return self.optional.contains(where: query)
     } else {
@@ -55,7 +55,7 @@ struct HealthKitObjectTypeRequirements {
     }
   }
 
-  var allObjectTypes: Set<HKObjectType> {
+  public var allObjectTypes: Set<HKObjectType> {
     var objectTypes = self.required
     objectTypes.formUnion(self.optional)
     objectTypes.formUnion(self.supplementary)

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -1151,10 +1151,10 @@ extension VitalHealthKitClient {
     store.authorizationState(resource).isActive
   }
 
-  public func healthKitRequirements(for resource: VitalResource) -> HealthKitObjectTypeRequirements {
+  public static func healthKitRequirements(for resource: VitalResource) -> HealthKitObjectTypeRequirements {
     return toHealthKitTypes(resource: resource)
   }
-  
+
   public func dateOfLastSync(for resource: VitalResource) -> Date? {
     guard hasAskedForPermission(resource: resource) else {
       return nil

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -1150,6 +1150,10 @@ extension VitalHealthKitClient {
   public func hasAskedForPermission(resource: VitalResource) -> Bool {
     store.authorizationState(resource).isActive
   }
+
+  public func healthKitRequirements(for resource: VitalResource) -> HealthKitObjectTypeRequirements {
+    return toHealthKitTypes(resource: resource)
+  }
   
   public func dateOfLastSync(for resource: VitalResource) -> Date? {
     guard hasAskedForPermission(resource: resource) else {


### PR DESCRIPTION
After #242 was implemented that enables additional `HKObjectType` types to be requested there's a need to resolve the underlying HealthKit permissions from `VitalResource`. This change simply exposes the `toHealthKitTypes` requirements method as `healthKitRequirements(for resource: VitalResource)` via the `VitalHealthKitClient`.

## Use Case

Given that now we're able to request additional permissions for direct HealthKit access it makes sense to track the requested read permissions internally in a more atomic fashion - using `HKObjectType` instead of `VitalResource`. This is handy when we want to detect whether new permissions can be requested in cases when:

1. The user has upgraded to a new version of the app with the updated list of HealthKit permissions.
2. The user has upgraded the iOS version that enables new permissions to be requested.

That way from the consumer side we can flatten all the requested read permissions like so:

```swift
let vitalResourcesToRead: [VitalResource] = [.activity, .workout, .sleep]

var extraObjectTypesToRead: [HKObjectType] {
    get {
        var objectTypes: [HKObjectType] = []

        if #available(iOS 18.0, *) {
            objectTypes.append(HKCategoryType(.sleepApneaEvent))
            objectTypes.append(HKQuantityType(.appleSleepingBreathingDisturbances))
        }
        
        return objectTypes
    }
}

var allObjectTypesToRead: [HKObjectType] {
    get {
        var objectTypes = vitalResourcesToRead.flatMap { VitalHealthKitClient.shared.healthKitRequirements(for: $0).allObjectTypes }
        objectTypes.append(contentsOf: extraObjectTypesToRead)
        return objectTypes
    }
}

var healthKitAuthorizationStatuses: Dictionary<HKObjectType, Bool> {
    get {
        let healthStore = HKHealthStore()
        return allObjectTypesToRead.reduce(into: [HKObjectType: Bool]()) { result, objectType in
            result[objectType] = healthStore.authorizationStatus(for: objectType) != .notDetermined
        }
    }
}
```

We use `healthKitAuthorizationStatuses` dictionary in our app to check whether to show or hide the "Connect with Apple Health" CTA in the UI. If there's at least one permission that's `.notDetermined` that means the user can be prompted with the native HealthKit dialog again as there are new HealthKit permissions to be requested.