### PR TITLE
VIT-7712: Stop using HKHealthStore.stop(_:)

### DIFF
--- a/Tests/VitalHealthKitTests/StatisticalQueryTests.swift
+++ b/Tests/VitalHealthKitTests/StatisticalQueryTests.swift
@@ -29,5 +29,4 @@ class StatisticalQueryTests: XCTestCase {
       }
     }
   }
-
 }


### PR DESCRIPTION
The cause of the reported crash is likely that both `HKHealthStore.execute(_:)` and `HKHealthStore.stop(_:)` were not synchronized with the mutual exclusion inside `CancellableQueryHandle`. So a race condition amongst them can arise and cause the " already been executed and cannot be executed again" NSException.

---

Per documentation, `HKHealthStore.stop(_:)` was only intended for long-running queries with store observation.

> https://developer.apple.com/documentation/healthkit/hkhealthstore/1614173-stop
>
> Either an [HKObserverQuery](https://developer.apple.com/documentation/healthkit/hkobserverquery) instance or an [HKStatisticsCollectionQuery](https://developer.apple.com/documentation/healthkit/hkstatisticscollectionquery) instance.
>
> Use this method on long-running queries only. Most queries automatically stop after they have gathered the requested data. Long-running queries continue to operate on a background thread, watching the HealthKit store for updates. You can cancel these queries by using this method.

It was an oversight that we use it on all queries.


---


Also move the `HKHealthStore.execute(_:)` call to be protected by the `CancellableQueryHandle` internal lock.