### PR TITLE
DEV-223: Tweak how we store StoredAnchor.date for activity

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -917,7 +917,7 @@ func handleActivity(
   let proposedUpperBound = deviceTimeZoneCalendar.floatingDate(
     of: instruction.query.upperBound
   )
-  let lastSynced = deviceTimeZoneCalendar.floatingDate(
+  let lastSynced = GregorianCalendar.utc.floatingDate(
     of: vitalStorage.read(key: "activityDaySummary")?.date ?? .distantPast
   )
 
@@ -973,7 +973,15 @@ func handleActivity(
   // `date` saves the exclusive upper bound of this iteration, a la the inclusive lower bound of
   // the next iteration.
   let nextLowerBound = deviceTimeZoneCalendar.offset(workingUpperBound, byDays: 1)
-  let anchors = [StoredAnchor(key: "activityDaySummary", anchor: nil, date: deviceTimeZoneCalendar.startOfDay(nextLowerBound), vitalAnchors: nil, hasMore: hasMore)]
+  let anchors = [
+    StoredAnchor(
+      key: "activityDaySummary",
+      anchor: nil,
+      date: GregorianCalendar.utc.startOfDay(nextLowerBound),
+      vitalAnchors: nil,
+      hasMore: hasMore
+    )
+  ]
 
   return (patch, anchors: anchors)
 }


### PR DESCRIPTION
Always use `GregorianCalendar.utc` when we convert calendar dates to/from `StoredAnchor.date` so there can be no surprise when time zone changes.