### PR TITLE
Tweak historical stage prioritization logic again

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/Storage/SyncProgressStore.swift
+++ b/Sources/VitalHealthKit/HealthKit/Storage/SyncProgressStore.swift
@@ -66,6 +66,7 @@ public struct SyncProgress: Codable {
     public var isInProgress: Bool {
       switch self {
       case .deprioritized, .started, .readChunk, .uploadedChunk, .revalidatingSyncState:
+        // NOTE: prioritizeSync() relies on `.deprioritized` being considered as in progress here
         return true
       case .completed, .noData, .cancelled, .error, .timedOut:
         return false


### PR DESCRIPTION
Prioritisation did not kick in the expected way. Tweak the criteria again to restore the expected execution order.