### PR TITLE
DEV-261: Revert back to use -authorizationStatusForType:

### DIFF
--- a/Tests/VitalHealthKitTests/VitalHealthKitClientTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitClientTests.swift
@@ -10,22 +10,22 @@ class VitalHealthKitClientTests: XCTestCase {
     /// This shouldn't crash if called before VitaClient.configure
     VitalHealthKitClient.configure(
       .init(
-        // 2025-02-26
-        // While backgroundDeliveryEnabled: true works in simulator and real devices, it does not
-        // work in the XCTest environment due to opaque Swift Concurrency crashes.
-        backgroundDeliveryEnabled: false, logsEnabled: true
+        backgroundDeliveryEnabled: true, logsEnabled: true
       )
     )
   }
-  
-  func testAskingForPermissionsContinuesWithoutAuthentication() async {
-    
+
+  func testAskingForPermissionsContinuesWithoutAuthentication() async throws {
+
     await VitalClient.shared.signOut()
     let value = VitalHealthKitClient(store: .debug)
-    
+
     _ = value.hasAskedForPermission(resource: .body)
+    let status = try await value.permissionStatus(for: [.body])
+    XCTAssertTrue(status.keys.contains(.body))
+
     let permission = await value.ask(readPermissions: [.body], writePermissions: [])
-    
+
     XCTAssertEqual(permission, PermissionOutcome.success)
   }
 }


### PR DESCRIPTION
As part of the mitigation of some rare priority inversion encounters inside HealthKit internals, SDK 1.4.1 migrated to use the official asynchronous `getRequestStatusForAuthorization` method to obtain the request status.

However, `-getRequestStatusForAuthorization` ended up being more problematic, causing intermittent crashes at `voucher_adopt` (libdispatch level).

This PR partially reverts the mitigation, where we replace `-getRequestStatusForAuthorization` with the good old `-authorizationStatusForType:`.

The combination of `-authorizationStatusForType:` + a high QoS DispatchQueue appears to function normally in one reproducible case that would have otherwise crashed at `voucher_adopt`.