### PR TITLE
DEV-319: iOS SDK: Locally track time zone and wheelchair use history

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/UserHistoryStore.swift
+++ b/Sources/VitalHealthKit/HealthKit/UserHistoryStore.swift
@@ -1,0 +1,98 @@
+@_spi(VitalSDKInternals) import VitalCore
+import Foundation
+import HealthKit
+
+class UserHistoryStore: @unchecked Sendable {
+  static let shared = UserHistoryStore()
+
+  internal static var getCurrentTimeZone = { TimeZone.current }
+  static let keepMostRecent = 30
+
+  private var hasLoaded = false
+  private var data: [GregorianCalendar.FloatingDate: UserHistoryRecord] = [:]
+  private let lock = NSLock()
+
+  private let storage: VitalGistStorage
+
+  init(storage: VitalGistStorage = .shared) {
+    self.storage = storage
+  }
+
+  private func loadIfNeeded() {
+    if !hasLoaded {
+      hasLoaded = true
+      self.data = self.storage.get(UserTimeZoneHistory.self) ?? [:]
+    }
+  }
+
+  private func save() {
+    // Trim oldest entries if we go above `keepMostRecent` days.
+    let keysToDrop = self.data.keys.sorted(by: >).dropFirst(Self.keepMostRecent)
+
+    for key in keysToDrop {
+      self.data.removeValue(forKey: key)
+    }
+
+    try? self.storage.set(self.data, for: UserTimeZoneHistory.self)
+  }
+
+  func record(_ timeZone: TimeZone, date: GregorianCalendar.Date? = nil) {
+    let dateToUpdate = date ?? GregorianCalendar(timeZone: timeZone).floatingDate(of: Date())
+    let zoneId = timeZone.identifier
+    let wheelchairUse = try? HKHealthStore().wheelchairUse()
+
+    return lock.withLock {
+      loadIfNeeded()
+
+      let oldValue = self.data[dateToUpdate]
+      let newValue = UserHistoryRecord(timeZoneId: zoneId, wheelchairUse: wheelchairUse?.wheelchairUse == .yes)
+      self.data[dateToUpdate] = newValue
+
+      if oldValue != newValue {
+        save()
+      }
+    }
+  }
+
+  func resolver() -> Resolver {
+    let current = lock.withLock {
+      loadIfNeeded()
+      return self.data
+    }
+
+    return Resolver(data: current)
+  }
+
+  struct Resolver {
+    let data: [GregorianCalendar.FloatingDate: UserHistoryRecord]
+
+    func timeZone(for date: GregorianCalendar.FloatingDate) -> TimeZone {
+
+      if let zoneId = data[date]?.timeZoneId, let timeZone = TimeZone(identifier: zoneId) {
+        return timeZone
+      }
+
+      // Find the closest observation
+      if
+        let closestDate = data.keys.lazy.filter({ $0 < date }).max(),
+        let nextZoneId = data[closestDate]?.timeZoneId,
+        let timeZone = TimeZone(identifier: nextZoneId)
+      {
+        return timeZone
+      }
+
+      // No match, fallback to current time zone
+      return UserHistoryStore.getCurrentTimeZone()
+    }
+  }
+}
+
+struct UserHistoryRecord: Codable, Equatable {
+  let timeZoneId: String
+  let wheelchairUse: Bool?
+}
+
+enum UserTimeZoneHistory: GistKey {
+  typealias T = [GregorianCalendar.FloatingDate: UserHistoryRecord]
+  static var identifier: String { "vital_user_timezone_history" }
+}

--- a/Sources/VitalHealthKit/HealthKit/UserHistoryStore.swift
+++ b/Sources/VitalHealthKit/HealthKit/UserHistoryStore.swift
@@ -22,6 +22,7 @@ class UserHistoryStore: @unchecked Sendable {
     if !hasLoaded {
       hasLoaded = true
       self.data = self.storage.get(UserTimeZoneHistory.self) ?? [:]
+      VitalLogger.healthKit.info("loaded \(self.data.count) records", source: "UserHistoryStore")
     }
   }
 
@@ -50,6 +51,11 @@ class UserHistoryStore: @unchecked Sendable {
 
       if oldValue != newValue {
         save()
+
+        VitalLogger.healthKit.info(
+          "\(dateToUpdate) old: \(oldValue.map(String.init(describing:)) ?? "nil") new: \(newValue)",
+          source: "UserHistoryStore"
+        )
       }
     }
   }

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -907,6 +907,9 @@ extension VitalHealthKitClient {
     progressStore.recordSync(syncID, .started)
     progressReporter.syncBegin(syncID)
 
+    // Make sure the entry in UserHistoryStore for today is up to date.
+    UserHistoryStore.shared.record(TimeZone.current)
+
     // If we receive this payload in foreground, wrap the sync work in
     // a UIKit background task, in case the user will move the app to background soon.
 

--- a/Tests/VitalHealthKitTests/UserHistoryStoreTests.swift
+++ b/Tests/VitalHealthKitTests/UserHistoryStoreTests.swift
@@ -1,0 +1,83 @@
+@_spi(VitalSDKInternals) @testable import VitalCore
+@testable import VitalHealthKit
+import XCTest
+import Foundation
+
+let calendar = GregorianCalendar.utc
+let today = calendar.floatingDate(of: Date(timeIntervalSince1970: 1743011768))
+
+@available(iOS 16.0, *)
+class UserHistoryStoreTests: XCTestCase {
+  var directoryUrl: URL!
+  var store: UserHistoryStore!
+
+  override func setUpWithError() throws {
+    UserHistoryStore.getCurrentTimeZone = { TimeZone(identifier: "Asia/Tokyo")! }
+
+    directoryUrl = URL.temporaryDirectory.appending(component: "user-history-store-" + UUID().uuidString, directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: directoryUrl, withIntermediateDirectories: true)
+    store = UserHistoryStore(storage: VitalGistStorage(directoryURL: directoryUrl))
+  }
+
+  override func tearDownWithError() throws {
+    UserHistoryStore.getCurrentTimeZone = { TimeZone.current }
+    try FileManager.default.removeItem(at: directoryUrl)
+  }
+
+  func testLastObservationWins() {
+    store.record(TimeZone(identifier: "Europe/Berlin")!, date: today)
+    store.record(TimeZone(identifier: "Europe/London")!, date: today)
+
+    UserHistoryStore.getCurrentTimeZone = { TimeZone(identifier: "Asia/Tokyo")! }
+
+    let resolvedTimeZone = store.resolver().timeZone(for: today)
+    // Last observation wins
+    XCTAssertEqual(resolvedTimeZone, TimeZone(identifier: "Europe/London")!)
+  }
+
+  func testCanHaveMultipleObservationsForDifferentDays() {
+    let yesterday = calendar.offset(today, byDays: -1)
+    let weekAgo = calendar.offset(today, byDays: -7)
+    let twoWeeksAgo = calendar.offset(today, byDays: -14)
+
+    store.record(TimeZone(identifier: "America/New_York")!, date: weekAgo)
+    store.record(TimeZone(identifier: "Europe/Berlin")!, date: today)
+    store.record(TimeZone(identifier: "Europe/London")!, date: yesterday)
+
+    UserHistoryStore.getCurrentTimeZone = { TimeZone(identifier: "Asia/Tokyo")! }
+
+    let resolver = store.resolver()
+
+    XCTAssertEqual(resolver.timeZone(for: weekAgo), TimeZone(identifier: "America/New_York")!)
+    XCTAssertEqual(resolver.timeZone(for: today), TimeZone(identifier: "Europe/Berlin")!)
+    XCTAssertEqual(resolver.timeZone(for: yesterday), TimeZone(identifier: "Europe/London")!)
+
+    // No record; should use current timezone
+    XCTAssertEqual(resolver.timeZone(for: twoWeeksAgo), TimeZone(identifier: "Asia/Tokyo")!)
+  }
+
+  func testReturnCurrentTimeZone() {
+    let resolvedTimeZone = store.resolver().timeZone(for: today)
+    // No recorded observation; return current timezone
+    XCTAssertEqual(resolvedTimeZone, TimeZone(identifier: "Asia/Tokyo")!)
+  }
+
+  func testShouldPurgeExcessRecords() {
+    let start = calendar.offset(today, byDays: -89)
+
+    for date in calendar.enumerate(start ... today) {
+      store.record(TimeZone(identifier: "Europe/London")!, date: date)
+    }
+
+    let resolver = store.resolver()
+    let resolved = calendar.enumerate(start ... today).map { date in resolver.timeZone(for: date) }
+
+    // No recorded observation; return current timezone
+    XCTAssertEqual(
+      resolved,
+      Array(repeating: TimeZone(identifier: "Asia/Tokyo")!, count: 90 - UserHistoryStore.keepMostRecent)
+      + Array(repeating: TimeZone(identifier: "Europe/London")!, count: UserHistoryStore.keepMostRecent)
+    )
+  }
+}
+


### PR DESCRIPTION
* Introduce `UserHistoryStore` to keep a local on-device record of time zone and wheelchair use of the past 30 days.

* Use this record to improve activity daily summary recomputation.

    * When an end user moves to a new time zone, it no longer causes also the summaries for three prior days (`activityStatsDaysToLookback`) to change to the new time zone. Instead, we would compute those days using the time zone recorded by `UserHistoryStore` for that day.