### PR TITLE
DEV-320, DEV-321: Update activity and distance resources with Wheelchair Mode support

### DIFF
--- a/Sources/VitalCore/Core/Client/Data Models/Base Models/VitalResource.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Base Models/VitalResource.swift
@@ -21,13 +21,13 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
       return 4
     case .workout, .individual(.vo2Max), .nutrition(.water), .nutrition(.caffeine):
       return 8
-    case .electrocardiogram, .heartRateAlert, .afibBurden, .standHour, .standDuration, .sleepApneaAlert, .sleepBreathingDisturbance, .wheelchairPush, .forcedExpiratoryVolume1, .forcedVitalCapacity, .peakExpiratoryFlowRate, .inhalerUsage, .fall, .uvExposure, .daylightExposure, .handwashing, .basalBodyTemperature:
+    case .electrocardiogram, .heartRateAlert, .afibBurden, .standHour, .standDuration, .sleepApneaAlert, .sleepBreathingDisturbance, .forcedExpiratoryVolume1, .forcedVitalCapacity, .peakExpiratoryFlowRate, .inhalerUsage, .fall, .uvExposure, .daylightExposure, .handwashing, .basalBodyTemperature:
       return 12
     case .vitals(.bloodOxygen), .vitals(.bloodPressure),
         .vitals(.glucose), .vitals(.heartRateVariability),
         .vitals(.mindfulSession), .vitals(.temperature), .vitals(.respiratoryRate):
       return 16
-    case .individual(.distance), .individual(.steps), .individual(.floorsClimbed):
+    case .individual(.distance), .individual(.steps), .individual(.floorsClimbed), .individual(.wheelchairPush):
       return 32
     case .vitals(.heartRate), .individual(.activeEnergyBurned), .individual(.basalEnergyBurned):
       return 64
@@ -99,7 +99,7 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
       return .sleepApneaAlert
     case .sleepBreathingDisturbance:
       return .sleepBreathingDisturbance
-    case .wheelchairPush:
+    case .individual(.wheelchairPush):
       return .wheelchairPush
     case .forcedExpiratoryVolume1:
       return .forcedExpiratoryVolume1
@@ -176,7 +176,8 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
     case distance
     case vo2Max
     case exerciseTime
-    
+    case wheelchairPush
+
     case weight
     case bodyFat
 
@@ -201,6 +202,8 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
           return "vo2Max"
         case .exerciseTime:
           return "exerciseTime"
+        case .wheelchairPush:
+          return "wheelchairPush"
         case .weight:
           return "weight"
         case .bodyFat:
@@ -226,7 +229,6 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
   case standDuration
   case sleepApneaAlert
   case sleepBreathingDisturbance
-  case wheelchairPush
   case forcedExpiratoryVolume1
   case forcedVitalCapacity
   case peakExpiratoryFlowRate
@@ -256,6 +258,7 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
     .vitals(.respiratoryRate),
 
     .individual(.steps),
+    .individual(.wheelchairPush),
     .individual(.floorsClimbed),
     .individual(.distance),
     .individual(.vo2Max),
@@ -274,7 +277,6 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
     .standDuration,
     .sleepApneaAlert,
     .sleepBreathingDisturbance,
-    .wheelchairPush,
     .forcedExpiratoryVolume1,
     .forcedVitalCapacity,
     .peakExpiratoryFlowRate,
@@ -322,8 +324,6 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
       return "sleepApneaAlert"
     case .sleepBreathingDisturbance:
       return "sleepBreathingDisturbance"
-    case .wheelchairPush:
-      return "wheelchairPush"
     case .forcedExpiratoryVolume1:
       return "forcedExpiratoryVolume1"
     case .forcedVitalCapacity:

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/ActivityPatch.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/ActivityPatch.swift
@@ -56,12 +56,17 @@ public struct ActivityPatch: Equatable, Encodable {
     public var restingHeartRate: Int?
     public var exerciseTime: Int?
 
+    public var distanceWheelchair: Double?
+    public var wheelchairUse: Bool?
+    public var wheelchairPush: Int?
+
     public var isNotEmpty: Bool {
       activeEnergyBurnedSum != nil || basalEnergyBurnedSum != nil ||
       stepsSum != nil || floorsClimbedSum != nil ||
       distanceWalkingRunningSum != nil || vo2Max != nil ||
       low != nil || medium != nil || high != nil || maxHeartRate != nil ||
       minHeartRate != nil || avgHeartRate != nil || restingHeartRate != nil || exerciseTime != nil
+      || distanceWheelchair != nil || wheelchairUse != nil || wheelchairPush != nil
     }
 
     public init(
@@ -79,7 +84,10 @@ public struct ActivityPatch: Equatable, Encodable {
       minHeartRate: Int? = nil,
       avgHeartRate: Int? = nil,
       restingHeartRate: Int? = nil,
-      exerciseTime: Int? = nil
+      exerciseTime: Int? = nil,
+      distanceWheelchair: Double? = nil,
+      wheelchairUse: Bool? = nil,
+      wheelchairPush: Int? = nil
     ) {
       self.calendarDate = calendarDate
       self.activeEnergyBurnedSum = activeEnergyBurnedSum
@@ -96,6 +104,9 @@ public struct ActivityPatch: Equatable, Encodable {
       self.avgHeartRate = avgHeartRate
       self.restingHeartRate = restingHeartRate
       self.exerciseTime = exerciseTime
+      self.distanceWheelchair = distanceWheelchair
+      self.wheelchairUse = wheelchairUse
+      self.wheelchairPush = wheelchairPush
     }
   }
   

--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -101,6 +101,9 @@ extension VitalHealthKitStore {
         HKSampleType.quantityType(forIdentifier: .stepCount)!,
         HKSampleType.quantityType(forIdentifier: .flightsClimbed)!,
         HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!,
+        HKSampleType.quantityType(forIdentifier: .distanceWheelchair)!,
+        // TODO: https://github.com/tryVital/vital-ios/pull/295
+        // HKSampleType.quantityType(forIdentifier: .pushCount)!,
         HKSampleType.quantityType(forIdentifier: .vo2Max)!,
         HKSampleType.quantityType(forIdentifier: .appleExerciseTime)!:
 

--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -102,8 +102,7 @@ extension VitalHealthKitStore {
         HKSampleType.quantityType(forIdentifier: .flightsClimbed)!,
         HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!,
         HKSampleType.quantityType(forIdentifier: .distanceWheelchair)!,
-        // TODO: https://github.com/tryVital/vital-ios/pull/295
-        // HKSampleType.quantityType(forIdentifier: .pushCount)!,
+        HKSampleType.quantityType(forIdentifier: .pushCount)!,
         HKSampleType.quantityType(forIdentifier: .vo2Max)!,
         HKSampleType.quantityType(forIdentifier: .appleExerciseTime)!:
 
@@ -202,9 +201,6 @@ extension VitalHealthKitStore {
 
     case HKSampleType.quantityType(forIdentifier: .appleStandTime)!:
       return [.standDuration]
-
-    case HKSampleType.quantityType(forIdentifier: .pushCount)!:
-      return [.wheelchairPush]
 
     case HKSampleType.quantityType(forIdentifier: .forcedExpiratoryVolume1)!:
       return [.forcedExpiratoryVolume1]

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -372,7 +372,7 @@ func read(
       return (nil, [])
     }
 
-  case .wheelchairPush:
+  case .individual(.wheelchairPush):
     let payload = try await handleTimeSeries(
       .pushCount,
       healthKitStore: healthKitStore,

--- a/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
@@ -86,14 +86,17 @@ extension HKSampleType {
         return .individual(.floorsClimbed)
         
       case HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!:
-        return .individual(.distanceWalkingRunning)
+        return .individual(.distance)
 
       case HKSampleType.quantityType(forIdentifier: .vo2Max)!:
         return .individual(.vo2Max)
 
       case HKSampleType.quantityType(forIdentifier: .appleExerciseTime)!:
         return .individual(.exerciseTime)
-        
+
+      case HKSampleType.quantityType(forIdentifier: .distanceWheelchair)!:
+          return .individual(.distance)
+
       default:
         fatalError("\(String(describing: self)) is not supported. This is a developer error")
     }
@@ -250,6 +253,9 @@ struct QuantityUnit {
     mapping[.stepCount] = .count
     mapping[.flightsClimbed] = .count
     mapping[.distanceWalkingRunning] = .meter
+    mapping[.distanceWheelchair] = .meter
+    mapping[.pushCount] = .count
+    mapping[.distanceWalkingRunning] = .meter
     mapping[.vo2Max] = .vo2Max
     mapping[.bloodGlucose] = .glucose
     mapping[.bloodPressureSystolic] = .mmHg
@@ -338,6 +344,8 @@ struct QuantityUnit {
     mapping[.stepCount] = .count()
     mapping[.flightsClimbed] = .count()
     mapping[.distanceWalkingRunning] = .meter()
+    mapping[.distanceWheelchair] = .meter()
+    mapping[.pushCount] = .count()
     mapping[.vo2Max] = .literUnit(with: .milli).unitDivided(by: .gramUnit(with: .kilo).unitMultiplied(by: .minute()))
     mapping[.bloodGlucose] = .moleUnit(with: .milli, molarMass: HKUnitMolarMassBloodGlucose).unitDivided(by: .liter())
     mapping[.bloodPressureSystolic] = .millimeterOfMercury()

--- a/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
@@ -95,7 +95,10 @@ extension HKSampleType {
         return .individual(.exerciseTime)
 
       case HKSampleType.quantityType(forIdentifier: .distanceWheelchair)!:
-          return .individual(.distance)
+        return .individual(.distance)
+
+      case HKSampleType.quantityType(forIdentifier: .pushCount)!:
+        return .individual(.wheelchairPush)
 
       default:
         fatalError("\(String(describing: self)) is not supported. This is a developer error")

--- a/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
@@ -347,7 +347,7 @@ func toHealthKitTypes(resource: VitalResource) -> HealthKitObjectTypeRequirement
       return HealthKitObjectTypeRequirements(required: [], optional: [], supplementary: [])
     }
 
-  case .wheelchairPush:
+  case .individual(.wheelchairPush):
     return single(HKSampleType.quantityType(forIdentifier: .pushCount)!)
 
   case .forcedExpiratoryVolume1:
@@ -461,8 +461,7 @@ func observedSampleTypes() -> [[HKSampleType]] {
       HKSampleType.quantityType(forIdentifier: .vo2Max)!,
       HKSampleType.quantityType(forIdentifier: .appleExerciseTime)!,
       HKSampleType.quantityType(forIdentifier: .distanceWheelchair)!,
-      // TODO: https://github.com/tryVital/vital-ios/pull/295
-      // HKSampleType.quantityType(forIdentifier: .pushCount)!,
+      HKSampleType.quantityType(forIdentifier: .pushCount)!,
     ],
 
     /// Meal

--- a/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
@@ -96,8 +96,17 @@ func toHealthKitTypes(resource: VitalResource) -> HealthKitObjectTypeRequirement
     return single(HKSampleType.quantityType(forIdentifier: .basalEnergyBurned)!)
   case .individual(.floorsClimbed):
     return single(HKSampleType.quantityType(forIdentifier: .flightsClimbed)!)
-  case .individual(.distanceWalkingRunning):
-    return single(HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!)
+  case .individual(.distance):
+    return HealthKitObjectTypeRequirements(
+      required: [],
+      optional: [
+        HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!,
+        HKSampleType.quantityType(forIdentifier: .distanceWheelchair)!,
+      ],
+      supplementary: [
+        HKCharacteristicType.characteristicType(forIdentifier: .wheelchairUse)!,
+      ]
+    )
   case .individual(.vo2Max):
     return single(HKSampleType.quantityType(forIdentifier: .vo2Max)!)
   case .individual(.exerciseTime):
@@ -160,11 +169,14 @@ func toHealthKitTypes(resource: VitalResource) -> HealthKitObjectTypeRequirement
         HKSampleType.quantityType(forIdentifier: .flightsClimbed)!,
         HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!,
         HKSampleType.quantityType(forIdentifier: .vo2Max)!,
-        HKSampleType.quantityType(forIdentifier: .appleExerciseTime)!
+        HKSampleType.quantityType(forIdentifier: .appleExerciseTime)!,
+        HKSampleType.quantityType(forIdentifier: .distanceWheelchair)!,
+        HKSampleType.quantityType(forIdentifier: .pushCount)!,
       ],
       supplementary: [
         HKSampleType.quantityType(forIdentifier: .heartRate)!,
         HKSampleType.quantityType(forIdentifier: .restingHeartRate)!,
+        HKCharacteristicType.characteristicType(forIdentifier: .wheelchairUse)!,
       ]
     )
 
@@ -447,7 +459,10 @@ func observedSampleTypes() -> [[HKSampleType]] {
       HKSampleType.quantityType(forIdentifier: .activeEnergyBurned)!,
       HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!,
       HKSampleType.quantityType(forIdentifier: .vo2Max)!,
-      HKSampleType.quantityType(forIdentifier: .appleExerciseTime)!
+      HKSampleType.quantityType(forIdentifier: .appleExerciseTime)!,
+      HKSampleType.quantityType(forIdentifier: .distanceWheelchair)!,
+      // TODO: https://github.com/tryVital/vital-ios/pull/295
+      // HKSampleType.quantityType(forIdentifier: .pushCount)!,
     ],
 
     /// Meal


### PR DESCRIPTION
* `activity`:

    * Compute `distanceWheelchair` sum & `pushCount` sum in Activity Day Summary.
    * Include `wheelchairUse` from UserHistoryStore.

* `distance`:
    * Now compute hourly statistics & per-device activity timeseries for both `distanceWalkingRunning` and `distanceWheelchair`.