### PR TITLE
DEV-323: New approach to sync Body Summary

### DIFF
--- a/Sources/VitalCore/Core/Client/Data Models/Base Models/VitalResource.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Base Models/VitalResource.swift
@@ -31,7 +31,8 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
       return 32
     case .vitals(.heartRate), .individual(.activeEnergyBurned), .individual(.basalEnergyBurned):
       return 64
-    case .individual(.exerciseTime), .individual(.weight), .individual(.bodyFat):
+    case .individual(.exerciseTime), .individual(.weight), .individual(.bodyFat),
+        .individual(.waistCircumference), .individual(.bodyMassIndex), .individual(.leanBodyMass):
       return Int.max
     }
   }
@@ -53,7 +54,7 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
       return BackfillType.floorsClimbed
     case .individual(.vo2Max):
       return BackfillType.vo2Max
-    case .body, .individual(.bodyFat), .individual(.weight):
+    case .body, .individual(.bodyFat), .individual(.weight), .individual(.bodyMassIndex), .individual(.waistCircumference), .individual(.leanBodyMass):
       return BackfillType.body;
     case .vitals(.bloodOxygen):
       return BackfillType.bloodOxygen;
@@ -180,6 +181,9 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
 
     case weight
     case bodyFat
+    case leanBodyMass
+    case waistCircumference
+    case bodyMassIndex
 
     @available(*, deprecated, renamed: "distance", message: "distanceWalkingRunning has been renamed to distance with the support for Wheelchair Mode")
     public static var distanceWalkingRunning: Self {
@@ -206,8 +210,14 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
           return "wheelchairPush"
         case .weight:
           return "weight"
-        case .bodyFat:
-          return "bodyFat"
+      case .bodyFat:
+        return "bodyFat"
+      case .leanBodyMass:
+        return "leanBodyMass"
+      case .waistCircumference:
+        return "waistCircumference"
+      case .bodyMassIndex:
+        return "bodyMassIndex"
       }
     }
   }
@@ -264,9 +274,13 @@ public enum VitalResource: Equatable, Hashable, Codable, Sendable {
     .individual(.vo2Max),
     .individual(.activeEnergyBurned),
     .individual(.basalEnergyBurned),
+    .individual(.exerciseTime),
     .individual(.weight),
     .individual(.bodyFat),
-    
+    .individual(.leanBodyMass),
+    .individual(.waistCircumference),
+    .individual(.bodyMassIndex),
+
     .nutrition(.water),
     .nutrition(.caffeine),
 

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/BodyPatch.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/BodyPatch.swift
@@ -1,12 +1,25 @@
 public struct BodyPatch: Equatable, Encodable {
   public let bodyMass: [LocalQuantitySample]
   public let bodyFatPercentage: [LocalQuantitySample]
-  
+  public let bodyMassIndex: [LocalQuantitySample]
+  public let waistCircumference: [LocalQuantitySample]
+  public let leanBodyMass: [LocalQuantitySample]
+
+  public let timeZones: [GregorianCalendar.FloatingDate: String]
+
   public  init(
     bodyMass: [LocalQuantitySample] = [],
-    bodyFatPercentage: [LocalQuantitySample] = []
+    bodyFatPercentage: [LocalQuantitySample] = [],
+    bodyMassIndex: [LocalQuantitySample] = [],
+    waistCircumference: [LocalQuantitySample] = [],
+    leanBodyMass: [LocalQuantitySample] = [],
+    timeZones: [GregorianCalendar.FloatingDate: String]
   ) {
     self.bodyMass = bodyMass
     self.bodyFatPercentage = bodyFatPercentage
+    self.bodyMassIndex = bodyMassIndex
+    self.waistCircumference = waistCircumference
+    self.leanBodyMass = leanBodyMass
+    self.timeZones = timeZones
   }
 }

--- a/Sources/VitalCore/Core/Client/Data Models/Patches/QuantitySample.swift
+++ b/Sources/VitalCore/Core/Client/Data Models/Patches/QuantitySample.swift
@@ -85,6 +85,7 @@ public struct LocalQuantitySample: Hashable, Encodable {
     case ug = "\u{03BC}g"
     case L
     case flowRate = "L/min"
+    case index
 
     public var description: String {
       rawValue

--- a/Sources/VitalHealthKit/HealthKit/Abstractions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Abstractions.swift
@@ -63,8 +63,8 @@ extension VitalHealthKitStore {
     // Remap individual resources to their composite version
     switch resource {
     case 
-        .individual(.bodyFat),
-        .individual(.weight):
+        .individual(.bodyFat), .individual(.weight), .individual(.leanBodyMass),
+        .individual(.waistCircumference), .individual(.bodyMassIndex):
       return RemappedVitalResource(wrapped: .body)
 
     case .individual(.exerciseTime):
@@ -82,7 +82,10 @@ extension VitalHealthKitStore {
     switch type {
       case
         HKQuantityType.quantityType(forIdentifier: .bodyMass)!,
-        HKQuantityType.quantityType(forIdentifier: .bodyFatPercentage)!:
+      HKQuantityType.quantityType(forIdentifier: .bodyFatPercentage)!,
+      HKQuantityType.quantityType(forIdentifier: .bodyMassIndex)!,
+      HKQuantityType.quantityType(forIdentifier: .leanBodyMass)!,
+      HKQuantityType.quantityType(forIdentifier: .waistCircumference)!:
 
       return [type.toIndividualResource, .body]
 

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads+Body.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads+Body.swift
@@ -1,0 +1,106 @@
+import VitalCore
+import HealthKit
+
+func calculateBodySummaryWorkingRangeUsingAnchoredQuery(
+  healthKitStore: HKHealthStore,
+  vitalStorage: AnchorStorage,
+  instruction: SyncInstruction,
+  in calendar: GregorianCalendar
+) async throws -> (ClosedRange<GregorianCalendar.FloatingDate>?, [StoredAnchor]) {
+  @Sendable func queryNewSampleDates(_ type: HKQuantityTypeIdentifier) async throws -> ([GregorianCalendar.FloatingDate], StoredAnchor?) {
+    return try await anchoredQuery(
+      healthKitStore: healthKitStore,
+      vitalStorage: vitalStorage,
+      type: HKQuantityType.quantityType(forIdentifier: type)!,
+      sampleClass: HKQuantitySample.self,
+      unit: QuantityUnit(type),
+      limit: 0,
+      startDate: instruction.query.lowerBound,
+      endDate: instruction.query.upperBound,
+      transform: { sample, _ in
+        if let zoneId = sample.metadata?[HKMetadataKeyTimeZone] as? String, let zone = TimeZone(identifier: zoneId) {
+          GregorianCalendar(timeZone: zone).floatingDate(of: sample.startDate)
+        } else {
+          calendar.floatingDate(of: sample.startDate)
+        }
+      }
+    )
+  }
+
+  async let _bodyMass = queryNewSampleDates(.bodyMass)
+  async let _bodyFatPercentage = queryNewSampleDates(.bodyFatPercentage)
+  async let _bodyMassIndex = queryNewSampleDates(.bodyMassIndex)
+  async let _waistCircumference = queryNewSampleDates(.waistCircumference)
+  async let _leanBodyMass = queryNewSampleDates(.leanBodyMass)
+
+  let (dates0, anchor0) = try await _bodyMass
+  let (dates1, anchor1) = try await _bodyFatPercentage
+  let (dates2, anchor2) = try await _bodyMassIndex
+  let (dates3, anchor3) = try await _waistCircumference
+  let (dates4, anchor4) = try await _leanBodyMass
+
+  let anchors = [anchor0, anchor1, anchor2, anchor3, anchor4].compactMap { $0 }
+  let minDate = [dates0, dates1, dates2, dates3, dates4].lazy.flatMap { $0 }.min()
+  let maxDate = [dates0, dates1, dates2, dates3, dates4].lazy.flatMap { $0 }.max()
+
+  if let minDate = minDate, let maxDate = maxDate {
+    return (minDate ... maxDate, anchors)
+  } else {
+    return (nil, anchors)
+  }
+}
+
+func queryBodySummaries(
+  healthKitStore: HKHealthStore,
+  start: GregorianCalendar.FloatingDate,
+  end: GregorianCalendar.FloatingDate,
+  in calendar: GregorianCalendar
+) async throws -> BodyPatch {
+  let firstInstant = calendar.startOfDay(start)
+  let lastInstantExclusive = calendar.startOfDay(calendar.offset(end, byDays: 1))
+
+  let samples = try await queryMulti(
+    healthKitStore: healthKitStore,
+    types: [
+      .quantityType(forIdentifier: .bodyMass)!,
+      .quantityType(forIdentifier: .bodyFatPercentage)!,
+      .quantityType(forIdentifier: .bodyMassIndex)!,
+      .quantityType(forIdentifier: .leanBodyMass)!,
+      .quantityType(forIdentifier: .waistCircumference)!,
+    ],
+    startDate: firstInstant,
+    endDate: lastInstantExclusive
+  )
+
+  var sampleObservedTimezones = [GregorianCalendar.FloatingDate: String]()
+
+  for sample in samples.values.flatMap({ $0 }) {
+    if
+      let zoneId = sample.metadata?[HKMetadataKeyTimeZone] as? String,
+      let zone = TimeZone(identifier: zoneId)
+    {
+      let date = GregorianCalendar(timeZone: zone).floatingDate(of: sample.startDate)
+      sampleObservedTimezones[date] = zoneId
+    }
+  }
+
+  // Fill in the blanks
+  let resolver = UserHistoryStore.shared.resolver()
+  for date in calendar.enumerate(start ... end) where !sampleObservedTimezones.keys.contains(date) {
+    sampleObservedTimezones[date] = resolver.timeZone(for: date).identifier
+  }
+
+  return BodyPatch(
+    bodyMass: (samples[.quantityType(forIdentifier: .bodyMass)!] ?? [])
+      .map { sample in LocalQuantitySample(sample as! HKQuantitySample, unit: QuantityUnit(.bodyMass)) },
+    bodyFatPercentage: (samples[.quantityType(forIdentifier: .bodyFatPercentage)!] ?? [])
+      .map { sample in LocalQuantitySample(sample as! HKQuantitySample, unit: QuantityUnit(.bodyFatPercentage)) },
+    bodyMassIndex: (samples[.quantityType(forIdentifier: .bodyMassIndex)!] ?? [])
+      .map { sample in LocalQuantitySample(sample as! HKQuantitySample, unit: QuantityUnit(.bodyMassIndex)) },
+    waistCircumference: (samples[.quantityType(forIdentifier: .waistCircumference)!] ?? [])
+      .map { sample in LocalQuantitySample(sample as! HKQuantitySample, unit: QuantityUnit(.waistCircumference)) },
+    leanBodyMass: (samples[.quantityType(forIdentifier: .leanBodyMass)!] ?? [])
+      .map { sample in LocalQuantitySample(sample as! HKQuantitySample, unit: QuantityUnit(.leanBodyMass)) },
+    timeZones: sampleObservedTimezones
+  )
+}

--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads+MenstrualCycle.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads+MenstrualCycle.swift
@@ -51,7 +51,6 @@ func handleMenstrualCycle(
 
   let sampleGroups = try await queryMulti(
     healthKitStore: healthKitStore,
-    vitalStorage: vitalStorage,
     types: types,
     startDate: searchLowerBound,
     endDate: searchUpperBound

--- a/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
@@ -48,31 +48,25 @@ extension ActivityPatch {
   }
 }
 
-extension BodyPatch {
-  init(sampleType: HKSampleType, samples: [LocalQuantitySample]) {
-    switch sampleType {
-      case .quantityType(forIdentifier: .bodyMass)!:
-        self.init(bodyMass: samples)
-        
-      case .quantityType(forIdentifier: .bodyFatPercentage)!:
-        self.init(bodyFatPercentage: samples)
-        
-      default:
-        fatalError("\(String(describing: sampleType)) cannot be used when constructing an BodyPatch")
-    }
-  }
-}
-
 extension HKSampleType {
   
   var toIndividualResource: VitalResource {
     switch self {
       case HKQuantityType.quantityType(forIdentifier: .bodyMass)!:
         return .individual(.weight)
-      
+
       case HKQuantityType.quantityType(forIdentifier: .bodyFatPercentage)!:
         return .individual(.bodyFat)
-      
+
+      case HKQuantityType.quantityType(forIdentifier: .bodyMassIndex)!:
+        return .individual(.bodyMassIndex)
+
+      case HKQuantityType.quantityType(forIdentifier: .leanBodyMass)!:
+        return .individual(.leanBodyMass)
+
+      case HKQuantityType.quantityType(forIdentifier: .waistCircumference)!:
+        return .individual(.waistCircumference)
+
       case HKSampleType.quantityType(forIdentifier: .activeEnergyBurned)!:
         return .individual(.activeEnergyBurned)
         
@@ -245,6 +239,10 @@ struct QuantityUnit {
 
     mapping[.bodyMass] = .kg
     mapping[.bodyFatPercentage] = .percentage
+    mapping[.bodyMassIndex] = .index
+    mapping[.leanBodyMass] = .kg
+    mapping[.waistCircumference] = .centimeter
+    mapping[.bodyFatPercentage] = .percentage
     mapping[.height] = .centimeter
     mapping[.heartRate] = .bpm
     mapping[.respiratoryRate] = .bpm
@@ -336,6 +334,9 @@ struct QuantityUnit {
 
     mapping[.bodyMass] = .gramUnit(with: .kilo)
     mapping[.bodyFatPercentage] = .percent()
+    mapping[.bodyMassIndex] = .count()
+    mapping[.leanBodyMass] = .gramUnit(with: .kilo)
+    mapping[.waistCircumference] = .meterUnit(with: .centi)
     mapping[.height] = .meterUnit(with: .centi)
     mapping[.heartRate] = .count().unitDivided(by: .minute())
     mapping[.respiratoryRate] = .count().unitDivided(by: .minute())

--- a/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/VitalResource+HealthKit.swift
@@ -115,6 +115,12 @@ func toHealthKitTypes(resource: VitalResource) -> HealthKitObjectTypeRequirement
     return single(HKSampleType.quantityType(forIdentifier: .bodyMass)!)
   case .individual(.bodyFat):
     return single(HKSampleType.quantityType(forIdentifier: .bodyFatPercentage)!)
+  case .individual(.bodyMassIndex):
+    return single(HKSampleType.quantityType(forIdentifier: .bodyMassIndex)!)
+  case .individual(.leanBodyMass):
+    return single(HKSampleType.quantityType(forIdentifier: .leanBodyMass)!)
+  case .individual(.waistCircumference):
+    return single(HKSampleType.quantityType(forIdentifier: .waistCircumference)!)
 
   case .vitals(.bloodOxygen):
     return single(HKSampleType.quantityType(forIdentifier: .oxygenSaturation)!)
@@ -443,7 +449,10 @@ func observedSampleTypes() -> [[HKSampleType]] {
     /// Body
     [
       HKQuantityType.quantityType(forIdentifier: .bodyMass)!,
-      HKQuantityType.quantityType(forIdentifier: .bodyFatPercentage)!
+      HKQuantityType.quantityType(forIdentifier: .bodyFatPercentage)!,
+      HKQuantityType.quantityType(forIdentifier: .bodyMassIndex)!,
+      HKQuantityType.quantityType(forIdentifier: .leanBodyMass)!,
+      HKQuantityType.quantityType(forIdentifier: .waistCircumference)!
     ],
 
     /// Sleep

--- a/Tests/VitalHealthKitTests/VitalResourceTests.swift
+++ b/Tests/VitalHealthKitTests/VitalResourceTests.swift
@@ -1,5 +1,5 @@
 import HealthKit
-import VitalCore
+@_spi(VitalSDKInternals) import VitalCore
 @testable import VitalHealthKit
 import XCTest
 
@@ -23,6 +23,19 @@ class VitalResourceTests: XCTestCase {
     XCTAssertTrue(UserDefaults(suiteName: "tryVital")!.bool(forKey: "vitals(VitalCore.VitalResource.Vitals.heartRate)"))
     XCTAssertTrue(VitalBackStorage.live.isResourceFlagged(.vitals(.heartRate)))
     // XCTAssertTrue(VitalBackStorage.live.isResourceFlagged(.vitals(.hearthRate)))
+  }
+
+  func test_priority_of_remapped_resources_should_be_Int_max() {
+    var invalid = Set<VitalResource>()
+
+    for resource in VitalResource.all {
+      let remapped = VitalHealthKitStore.remapResource(resource)
+      if remapped.wrapped != resource, resource.priority != Int.max {
+        invalid.insert(resource)
+      }
+    }
+
+    XCTAssertEqual(invalid, [])
   }
 
 }


### PR DESCRIPTION
1. Use AnchoredQuery on all 5 body quantity types to gather the changed dates.

2. Find the minimum and maximum changed dates.

3. Fetch all body quantity samples that fall inside this date range.

This was a past approach for Activity Summary. We ditched it for Activity because of performance issues with the amount of high(er)-frequency timeseries involved. However, Body is low frequency, typically _at most_ once or twice per day. So this approach should work fine.