### PR TITLE
DEV-944: Fix Resting Heart Rate not being included in activity summary on iOS 26.4+

### DIFF
--- a/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
+++ b/Sources/VitalHealthKit/HealthKit/HealthKitReads.swift
@@ -1982,6 +1982,7 @@ func queryActivityDaySummaries(
   let minHeartRate = keyedByDate(try await _minHeartRate)
   let averageHeartRate = keyedByDate(try await _averageHeartRate)
   let restingHeartRate = keyedByDate(try await _restingHeartRate)
+  
   let appleExerciseTime = keyedByDate(try await _appleExerciseTime)
   let distanceWheelchair = keyedByDate(try await _distanceWheelchair)
   let pushCount = keyedByDate(try await _pushCount)

--- a/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
+++ b/Sources/VitalHealthKit/HealthKit/Models/CoreModels+Extensions.swift
@@ -483,13 +483,9 @@ extension HKQuantityType {
       // We always want sum for cumulative quantity types.
       return [.cumulativeSum]
 
-    case .discreteArithmetic:
+    case .discreteArithmetic, .discreteTemporallyWeighted, .discreteEquivalentContinuousLevel:
       // Defaults to most recent reading.
       return [.mostRecent]
-
-    case .discreteTemporallyWeighted, .discreteEquivalentContinuousLevel:
-      // Not supported.
-      return []
 
     @unknown default:
       return []
@@ -503,13 +499,9 @@ extension HKQuantityType {
       // We always want sum for cumulative quantity types.
       return statistics.sumQuantity()
 
-    case .discreteArithmetic:
+    case .discreteArithmetic, .discreteTemporallyWeighted, .discreteEquivalentContinuousLevel:
       // Defaults to most recent reading.
       return statistics.mostRecentQuantity()
-
-    case .discreteTemporallyWeighted, .discreteEquivalentContinuousLevel:
-      // Not supported.
-      return nil
 
     @unknown default:
       return nil


### PR DESCRIPTION
In iOS 26.4, Apple silently changed the Resting Heart Rate's "aggregation style" classification from "discrete arithmetic" to "discrete temporally weighed".

That led to our activity daily summary logic stop doing aggregations on it, since historically we don't pull any resources that are "discrete temporally weighed".

