### PR TITLE
Serialize automatic invalidation with external-user identification

### DIFF
--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -152,6 +152,42 @@ public enum AuthenticateRequest {
   case signInToken(rawToken: String)
 }
 
+private final class AutomaticSignOutState: @unchecked Sendable {
+  private let parkingLot = ParkingLot()
+  private let lock = NSLock()
+  private var generation: UInt = 0
+  private var isActive = false
+
+  func begin() -> Bool {
+    guard parkingLot.tryTo(.enable) else {
+      return false
+    }
+
+    lock.withLock {
+      generation &+= 1
+      isActive = true
+    }
+    return true
+  }
+
+  func finish() {
+    lock.withLock { isActive = false }
+    precondition(parkingLot.tryTo(.disable), "Automatic sign-out was not active")
+  }
+
+  func waitUntilIdle() async throws {
+    try await parkingLot.parkIfNeeded()
+  }
+
+  var generationIfIdle: UInt? {
+    lock.withLock { isActive ? nil : generation }
+  }
+
+  func hasChanged(since priorGeneration: UInt) -> Bool {
+    lock.withLock { isActive || generation != priorGeneration }
+  }
+}
+
 @objc public class VitalClient: NSObject {
   public static let sdkVersion = "1.8.8"
 
@@ -177,17 +213,25 @@ public enum AuthenticateRequest {
   private var postSignoutTasks: [@Sendable () async -> Void] = []
 
   private static let identifyParkingLot = ParkingLot()
-  private static let automaticSignOutParkingLot = ParkingLot()
+  private static let automaticSignOutState = AutomaticSignOutState()
 
   internal static func scheduleAutomaticSignOut(
     _ action: @Sendable @escaping () async -> Void
   ) {
-    guard automaticSignOutParkingLot.tryTo(.enable) else {
+    guard automaticSignOutState.begin() else {
       return
     }
     Task {
-      defer { _ = automaticSignOutParkingLot.tryTo(.disable) }
+      do {
+        try await identifyParkingLot.semaphore.acquire()
+      } catch {
+        automaticSignOutState.finish()
+        return
+      }
+
       await action()
+      identifyParkingLot.semaphore.release()
+      automaticSignOutState.finish()
     }
   }
 
@@ -304,14 +348,38 @@ public enum AuthenticateRequest {
     // Make sure client has been setup & automaticConfiguration has been ran once
     _ = shared
 
-    // Invalid JWT state schedules sign-out from a synchronous Combine sink.
-    // Wait for that teardown to finish before a new identity can be installed,
-    // otherwise the delayed sign-out can erase the newly created session.
-    try await automaticSignOutParkingLot.parkIfNeeded()
+    while true {
+      // Automatic invalid-user sign-out and identify share one lifecycle lock.
+      // If invalidation begins during identify, finish that attempt, let the
+      // queued sign-out clear it, then identify again from a clean state.
+      try await automaticSignOutState.waitUntilIdle()
+      try await identifyParkingLot.semaphore.acquire()
 
-    // Only one `identify` is allowed to run at any given time.
-    try await identifyParkingLot.semaphore.acquire()
-    defer { identifyParkingLot.semaphore.release() }
+      guard let generation = automaticSignOutState.generationIfIdle else {
+        identifyParkingLot.semaphore.release()
+        continue
+      }
+
+      do {
+        try await performIdentifyExternalUser(externalUserId, authenticate: authenticate)
+      } catch {
+        identifyParkingLot.semaphore.release()
+        throw error
+      }
+
+      let wasInvalidated = automaticSignOutState.hasChanged(since: generation)
+      identifyParkingLot.semaphore.release()
+
+      if wasInvalidated == false {
+        return
+      }
+    }
+  }
+
+  private static func performIdentifyExternalUser(
+    _ externalUserId: String,
+    authenticate: @Sendable (_ externalUserId: String) async throws -> AuthenticateRequest
+  ) async throws {
 
     let existingParams = Current.startupParamsStorage.get()
 

--- a/Sources/VitalCore/Core/Client/VitalClient.swift
+++ b/Sources/VitalCore/Core/Client/VitalClient.swift
@@ -177,6 +177,19 @@ public enum AuthenticateRequest {
   private var postSignoutTasks: [@Sendable () async -> Void] = []
 
   private static let identifyParkingLot = ParkingLot()
+  private static let automaticSignOutParkingLot = ParkingLot()
+
+  internal static func scheduleAutomaticSignOut(
+    _ action: @Sendable @escaping () async -> Void
+  ) {
+    guard automaticSignOutParkingLot.tryTo(.enable) else {
+      return
+    }
+    Task {
+      defer { _ = automaticSignOutParkingLot.tryTo(.disable) }
+      await action()
+    }
+  }
 
   public static var shared: VitalClient {
     let sharedClient = sharedNoAutoConfig
@@ -290,6 +303,11 @@ public enum AuthenticateRequest {
 
     // Make sure client has been setup & automaticConfiguration has been ran once
     _ = shared
+
+    // Invalid JWT state schedules sign-out from a synchronous Combine sink.
+    // Wait for that teardown to finish before a new identity can be installed,
+    // otherwise the delayed sign-out can erase the newly created session.
+    try await automaticSignOutParkingLot.parkIfNeeded()
 
     // Only one `identify` is allowed to run at any given time.
     try await identifyParkingLot.semaphore.acquire()
@@ -584,7 +602,7 @@ public enum AuthenticateRequest {
     jwtAuth.statusDidChange
       .filter { $0 == .userNoLongerValid }
       .sink { _ in
-        Task {
+        scheduleAutomaticSignOut {
           await client.signOut()
         }
       }

--- a/Sources/VitalHealthKit/HealthKit/Concurrency.swift
+++ b/Sources/VitalHealthKit/HealthKit/Concurrency.swift
@@ -14,12 +14,38 @@ final class TaskHandle: Hashable, @unchecked Sendable {
     wrapped?.cancel()
   }
 
+  func wait() async {
+    guard let wrapped = wrapped else { return }
+    _ = await wrapped.result
+  }
+
   static func ==(lhs: TaskHandle, rhs: TaskHandle) -> Bool {
     lhs === rhs
   }
 
   func hash(into hasher: inout Hasher) {
     hasher.combine(ObjectIdentifier(self))
+  }
+}
+
+final class OneShotCompletion<Value>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var completion: ((Value) -> Void)?
+
+  init(_ completion: @escaping (Value) -> Void) {
+    self.completion = completion
+  }
+
+  @discardableResult
+  func complete(_ value: Value) -> Bool {
+    let completion: ((Value) -> Void)? = lock.withLock {
+      defer { self.completion = nil }
+      return self.completion
+    }
+
+    guard let completion = completion else { return false }
+    completion(value)
+    return true
   }
 }
 

--- a/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
+++ b/Sources/VitalHealthKit/HealthKit/VitalHealthKitClient.swift
@@ -6,6 +6,15 @@ import UIKit
 import BackgroundTasks
 
 let processingTaskIdentifier = "io.tryvital.VitalHealthKit.ProcessingTask"
+let processingTaskRetryInterval: TimeInterval = 6 * 60 * 60
+
+func makeProcessingTaskRequest(now: Date = Date()) -> BGProcessingTaskRequest {
+  let request = BGProcessingTaskRequest(identifier: processingTaskIdentifier)
+  request.requiresExternalPower = false
+  request.requiresNetworkConnectivity = true
+  request.earliestBeginDate = now.addingTimeInterval(processingTaskRetryInterval)
+  return request
+}
 
 public enum PermissionStatus: Equatable, Sendable {
   case asked
@@ -16,6 +25,85 @@ public enum PermissionOutcome: Equatable, Sendable {
   case success
   case failure(String)
   case healthKitNotAvailable
+}
+
+final class BackgroundDeliveryEnablementState: @unchecked Sendable {
+  private let lock = NSLock()
+  private var nextAttemptID: UInt = 0
+  private var latestAttemptIDs: [HKSampleType: UInt] = [:]
+  private var failedSampleTypes: Set<HKSampleType> = []
+
+  func beginAttempt(for sampleType: HKSampleType) -> UInt {
+    lock.withLock {
+      nextAttemptID &+= 1
+      latestAttemptIDs[sampleType] = nextAttemptID
+      return nextAttemptID
+    }
+  }
+
+  @discardableResult
+  func record(
+    _ sampleType: HKSampleType,
+    attemptID: UInt,
+    succeeded: Bool
+  ) -> Bool {
+    lock.withLock {
+      guard latestAttemptIDs[sampleType] == attemptID else {
+        return false
+      }
+
+      if succeeded {
+        failedSampleTypes.remove(sampleType)
+      } else {
+        failedSampleTypes.insert(sampleType)
+      }
+      return true
+    }
+  }
+
+  var hasFailures: Bool {
+    lock.withLock { !failedSampleTypes.isEmpty }
+  }
+
+  func failures(intersecting sampleTypes: Set<HKSampleType>) -> Set<HKSampleType> {
+    lock.withLock {
+      failedSampleTypes.formIntersection(sampleTypes)
+
+      let removedSampleTypes = latestAttemptIDs.keys.filter {
+        !sampleTypes.contains($0)
+      }
+      for sampleType in removedSampleTypes {
+        latestAttemptIDs.removeValue(forKey: sampleType)
+      }
+
+      return failedSampleTypes
+    }
+  }
+
+  func reset() {
+    lock.withLock {
+      failedSampleTypes.removeAll()
+      latestAttemptIDs.removeAll()
+    }
+  }
+}
+
+final class BackgroundProcessingTaskState: @unchecked Sendable {
+  private let lock = NSLock()
+  private var expired = false
+  private var succeeded = false
+
+  func markExpired() {
+    lock.withLock { expired = true }
+  }
+
+  func markSucceeded() {
+    lock.withLock { succeeded = true }
+  }
+
+  var shouldCompleteSuccessfully: Bool {
+    lock.withLock { succeeded && !expired }
+  }
 }
 
 @objc public class VitalHealthKitClient: NSObject {
@@ -68,6 +156,7 @@ public enum PermissionOutcome: Equatable, Sendable {
 
   private let _status: PassthroughSubject<Status, Never>
   private var backgroundDeliveryTask: BackgroundDeliveryTask? = nil
+  private let backgroundDeliveryEnablement = BackgroundDeliveryEnablementState()
 
   private var cancellables: Set<AnyCancellable> = []
 
@@ -130,6 +219,7 @@ public enum PermissionOutcome: Equatable, Sendable {
         break
 
       case .foreground:
+        client.retryFailedBackgroundDeliveryEnablement()
         client.scheduleDeprioritizedResourceRetries()
 
         // Sync profile since most of the content is not observable.
@@ -318,29 +408,37 @@ extension VitalHealthKitClient {
 
     let state = try await authorizationState(store: self.store)
     let currentTask = self.backgroundDeliveryTask
-
-    // Reconfigure the task only if the set of resources has changed, or we have not configured it
-    // before.
-    guard
+    let shouldReconfigureObservers =
       state.activeResources != currentTask?.resources
-        || state.determinedObjectTypes != currentTask?.objectTypes
-    else { return }
-
-    /// If it's already running, cancel it
-    currentTask?.cancel()
+      || state.determinedObjectTypes != currentTask?.objectTypes
 
     let bundles: Set<[HKSampleType]> = Set(
       observedSampleTypes()
         .map { Set($0).intersection(state.determinedObjectTypes).compactMap { $0 as? HKSampleType } }
         .filter { !$0.isEmpty }
     )
+    let observedSampleTypes = Set(bundles.lazy.flatMap { $0 })
+    let failedSampleTypes = backgroundDeliveryEnablement.failures(
+      intersecting: observedSampleTypes
+    )
+
+    guard shouldReconfigureObservers || !failedSampleTypes.isEmpty else { return }
+
+    if shouldReconfigureObservers {
+      currentTask?.cancel()
+    }
 
     if bundles.isEmpty {
       VitalLogger.healthKit.info("Not observing any type")
     }
 
-    /// Enable background deliveries
-    enableBackgroundDelivery(for: bundles.lazy.flatMap { $0 })
+    let sampleTypesToEnable = shouldReconfigureObservers
+      ? observedSampleTypes
+      : failedSampleTypes
+    enableBackgroundDelivery(for: sampleTypesToEnable)
+
+    // Retrying enablement must not replace healthy observer queries.
+    guard shouldReconfigureObservers else { return }
 
     /// Submit BGProcessingTasks
     scope.task { await self.submitProcessingTasks() }
@@ -434,11 +532,29 @@ extension VitalHealthKitClient {
     )
   }
 
-  private func enableBackgroundDelivery(for sampleTypes: some Sequence<HKSampleType>) {
-    for sampleType in sampleTypes {
-      store.enableBackgroundDelivery(sampleType, .immediate) { success, failure in
+  private func retryFailedBackgroundDeliveryEnablement() {
+    guard backgroundDeliveryEnablement.hasFailures else { return }
 
-        guard failure == nil && success else {
+    scope.task(priority: .high) { @MainActor in
+      let enabled = await self.backgroundDeliveryEnabled.get()
+      try await self.checkBackgroundUpdates(isBackgroundEnabled: enabled)
+    }
+  }
+
+  private func enableBackgroundDelivery(for sampleTypes: some Sequence<HKSampleType>) {
+    let enablementState = backgroundDeliveryEnablement
+
+    for sampleType in sampleTypes {
+      let attemptID = enablementState.beginAttempt(for: sampleType)
+      store.enableBackgroundDelivery(sampleType, .immediate) { success, failure in
+        let succeeded = failure == nil && success
+        guard enablementState.record(
+          sampleType,
+          attemptID: attemptID,
+          succeeded: succeeded
+        ) else { return }
+
+        guard succeeded else {
           VitalLogger.healthKit.error("failed: \(sampleType.shortenedIdentifier); error = \(String(describing: failure))", source: "EnableBgDelivery")
           return
         }
@@ -457,23 +573,21 @@ extension VitalHealthKitClient {
       scheduler.register(forTaskWithIdentifier: processingTaskIdentifier, using: nil) { task in
 
         VitalLogger.healthKit.info("begin", source: "ProcessingTask")
-        defer { VitalLogger.healthKit.info("ended", source: "ProcessingTask") }
 
-        task.expirationHandler = {
-          VitalLogger.healthKit.info("expired", source: "ProcessingTask")
-          SyncProgressStore.shared.flush()
-          task.setTaskCompleted(success: false)
+        let processingState = BackgroundProcessingTaskState()
+        let completion = OneShotCompletion<Bool> { success in
+          task.setTaskCompleted(success: success)
         }
-
-        self.scope.task(priority: .userInitiated) {
-          defer {
-            task.setTaskCompleted(success: true)
-          }
-
+        let work = self.scope.task(priority: .userInitiated) {
           guard VitalClient.status.contains(.signedIn) else {
             VitalLogger.healthKit.info("not signed in", source: "ProcessingTask")
+            processingState.markSucceeded()
             return
           }
+
+          // Keep a successor request pending even if this run expires while syncing.
+          await self.submitProcessingTasks()
+          try Task.checkCancellation()
 
           let state = try await authorizationState(store: self.store)
 
@@ -487,7 +601,24 @@ extension VitalHealthKitClient {
             }
           }
 
-          await self.submitProcessingTasks()
+          try Task.checkCancellation()
+          processingState.markSucceeded()
+        }
+
+        task.expirationHandler = {
+          VitalLogger.healthKit.info("expired", source: "ProcessingTask")
+          processingState.markExpired()
+          work?.cancel()
+          SyncProgressStore.shared.flush()
+        }
+
+        Task(priority: .userInitiated) {
+          if let work = work {
+            await work.wait()
+          }
+          SyncProgressStore.shared.flush()
+          completion.complete(processingState.shouldCompleteSuccessfully)
+          VitalLogger.healthKit.info("ended", source: "ProcessingTask")
         }
       }
     }
@@ -504,19 +635,7 @@ extension VitalHealthKitClient {
         return
       }
 
-      let request: BGProcessingTaskRequest
-
-      if #available(iOS 17.0, *) {
-        request = BGHealthResearchTaskRequest(identifier: processingTaskIdentifier)
-      } else {
-        request = BGProcessingTaskRequest(identifier: processingTaskIdentifier)
-      }
-
-      request.requiresExternalPower = true
-      request.requiresNetworkConnectivity = true
-
-      // Processing Tasks should be at minimum 6 hours apart
-      request.earliestBeginDate = Date().addingTimeInterval(3600 * 6)
+      let request = makeProcessingTaskRequest()
 
       do {
         try scheduler.submit(request)
@@ -595,9 +714,11 @@ extension VitalHealthKitClient {
         }
 
         let query = HKObserverQuery(queryDescriptors: descriptors) { query, sampleTypes, handler, error in
+          let observerCompletion = OneShotCompletion<Void> { handler() }
 
           guard error == nil else {
             VitalLogger.healthKit.error("observer errored for \(typesToObserve.map(\.shortenedIdentifier)); error = \(String(describing: error)).", source: "HealthKit")
+            observerCompletion.complete(())
             return
           }
 
@@ -605,6 +726,7 @@ extension VitalHealthKitClient {
           // populated.
           guard let sampleTypes = sampleTypes else {
             VitalLogger.healthKit.error("unexpected callout with no sample type", source: "HealthKit")
+            observerCompletion.complete(())
             return
           }
 
@@ -614,7 +736,7 @@ extension VitalHealthKitClient {
           let filteredSampleTypes = sampleTypes.intersection(typesToObserve)
 
           if filteredSampleTypes.isEmpty {
-            handler()
+            observerCompletion.complete(())
           } else {
 
             let matches = Set(filteredSampleTypes.flatMap(VitalHealthKitStore.sampleTypeToVitalResource(type:)))
@@ -625,13 +747,13 @@ extension VitalHealthKitClient {
               resources: remapped,
               completion: { completion in
                 if completion == .completed {
-                  handler()
+                  observerCompletion.complete(())
                 }
               }
             )
             VitalLogger.healthKit.info("notified: \(payload)", source: "HealthKit")
 
-            continuation.yield(.received(payload))
+            yieldBackgroundDeliveryPayload(payload, to: continuation)
 
             SyncProgressStore.shared.recordSystem(
               remapped,
@@ -667,9 +789,11 @@ extension VitalHealthKitClient {
 
       for sampleType in sampleTypes {
         let query = HKObserverQuery(sampleType: sampleType, predicate: nil) { query, handler, error in
+          let observerCompletion = OneShotCompletion<Void> { handler() }
 
           guard error == nil else {
             VitalLogger.healthKit.error("observer errored for \(sampleType.shortenedIdentifier); error = \(String(describing: error)).", source: "HealthKit")
+            observerCompletion.complete(())
             return
           }
 
@@ -683,13 +807,13 @@ extension VitalHealthKitClient {
             resources: remapped,
             completion: { completion in
               if completion == .completed {
-                handler()
+                observerCompletion.complete(())
               }
             }
           )
           VitalLogger.healthKit.info("notified: \(payload)", source: "HealthKit")
 
-          continuation.yield(.received(payload))
+          yieldBackgroundDeliveryPayload(payload, to: continuation)
 
           SyncProgressStore.shared.recordSystem(
             remapped,
@@ -745,6 +869,7 @@ extension VitalHealthKitClient {
 
     backgroundDeliveryTask = nil
     backgroundDeliveryEnabled.set(value: false)
+    backgroundDeliveryEnablement.reset()
 
     SyncProgressStore.shared.clear()
     storage.clean()
@@ -1451,6 +1576,24 @@ extension VitalHealthKitClient {
 enum BackgroundDeliveryStage {
   case received(BackgroundDeliveryPayload)
   case evaluate
+}
+
+func yieldBackgroundDeliveryPayload(
+  _ payload: BackgroundDeliveryPayload,
+  to continuation: AsyncStream<BackgroundDeliveryStage>.Continuation
+) {
+  switch continuation.yield(.received(payload)) {
+  case .enqueued(_):
+    break
+  case let .dropped(stage):
+    if case let .received(droppedPayload) = stage {
+      droppedPayload.completion(.completed)
+    }
+  case .terminated:
+    payload.completion(.completed)
+  @unknown default:
+    payload.completion(.completed)
+  }
 }
 
 enum PipelineStage {

--- a/Tests/VitalCoreTests/VitalClientTests.swift
+++ b/Tests/VitalCoreTests/VitalClientTests.swift
@@ -225,6 +225,35 @@ class VitalClientTests: XCTestCase {
     XCTAssertEqual(VitalClient.identifiedExternalUser, "replacement-user")
   }
 
+  func testIdentifyRetriesAfterAutomaticSignOutBeginsDuringAuthentication() async throws {
+    let authenticationAttempts = AsyncCounter()
+    let signOutFinished = AsyncFlag()
+    let secondAttemptFollowedSignOut = AsyncFlag()
+
+    try await VitalClient.identifyExternalUser("replacement-user") { _ in
+      let attempt = await authenticationAttempts.increment()
+
+      if attempt == 1 {
+        VitalClient.scheduleAutomaticSignOut {
+          await VitalClient.shared.signOut()
+          await signOutFinished.set()
+        }
+      } else if await signOutFinished.value {
+        await secondAttemptFollowedSignOut.set()
+      }
+
+      return .apiKey(key: apiKey, userId: userId, environment)
+    }
+
+    let attemptCount = await authenticationAttempts.value
+    let didFinishSignOut = await signOutFinished.value
+    let didRetryAfterSignOut = await secondAttemptFollowedSignOut.value
+    XCTAssertEqual(attemptCount, 2)
+    XCTAssertTrue(didFinishSignOut)
+    XCTAssertTrue(didRetryAfterSignOut)
+    XCTAssertEqual(VitalClient.identifiedExternalUser, "replacement-user")
+  }
+
   func testRestorationStateBackwardCompatibility() throws {
     let decoder = JSONDecoder()
 
@@ -280,5 +309,14 @@ private actor AsyncFlag {
 
   func set() {
     value = true
+  }
+}
+
+private actor AsyncCounter {
+  private(set) var value = 0
+
+  func increment() -> Int {
+    value += 1
+    return value
   }
 }

--- a/Tests/VitalCoreTests/VitalClientTests.swift
+++ b/Tests/VitalCoreTests/VitalClientTests.swift
@@ -196,6 +196,35 @@ class VitalClientTests: XCTestCase {
     XCTAssertTrue(config2.localDebug)
   }
 
+  func testIdentifyWaitsForAutomaticSignOutToFinish() async throws {
+    let signOutGate = SuspensionGate()
+    let authentication = AsyncFlag()
+
+    VitalClient.scheduleAutomaticSignOut {
+      await signOutGate.wait()
+    }
+
+    let identify = Task {
+      try await VitalClient.identifyExternalUser("replacement-user") { _ in
+        await authentication.set()
+        return .apiKey(key: apiKey, userId: userId, environment)
+      }
+    }
+
+    while await signOutGate.isWaiting == false {
+      await Task.yield()
+    }
+    let authenticatedBeforeSignOut = await authentication.value
+    XCTAssertFalse(authenticatedBeforeSignOut)
+
+    await signOutGate.release()
+    try await identify.value
+
+    let authenticatedAfterSignOut = await authentication.value
+    XCTAssertTrue(authenticatedAfterSignOut)
+    XCTAssertEqual(VitalClient.identifiedExternalUser, "replacement-user")
+  }
+
   func testRestorationStateBackwardCompatibility() throws {
     let decoder = JSONDecoder()
 
@@ -228,5 +257,28 @@ class VitalClientTests: XCTestCase {
       VitalClientRestorationState(configuration: .init(logsEnable: true), apiVersion: "v2", apiKey: "", environment: nil, strategy: .jwt(.sandbox(.eu)))
     )
     XCTAssertEqual(try state3.resolveStrategy(), .jwt(.sandbox(.eu)))
+  }
+}
+
+private actor SuspensionGate {
+  private var continuation: CheckedContinuation<Void, Never>?
+  private(set) var isWaiting = false
+
+  func wait() async {
+    isWaiting = true
+    await withCheckedContinuation { continuation = $0 }
+  }
+
+  func release() {
+    continuation?.resume()
+    continuation = nil
+  }
+}
+
+private actor AsyncFlag {
+  private(set) var value = false
+
+  func set() {
+    value = true
   }
 }

--- a/Tests/VitalHealthKitTests/VitalHealthKitClientTests.swift
+++ b/Tests/VitalHealthKitTests/VitalHealthKitClientTests.swift
@@ -1,5 +1,8 @@
 import XCTest
+import BackgroundTasks
 import HealthKit
+import Foundation
+import Dispatch
 
 @testable import VitalHealthKit
 @testable import VitalCore
@@ -27,5 +30,113 @@ class VitalHealthKitClientTests: XCTestCase {
     let permission = await value.ask(readPermissions: [.body], writePermissions: [])
 
     XCTAssertEqual(permission, PermissionOutcome.success)
+  }
+
+  func testOneShotCompletionInvokesCallbackOnlyOnceUnderRace() {
+    let counter = LockedCounter()
+    let completion = OneShotCompletion<Void> { _ in
+      counter.increment()
+    }
+
+    DispatchQueue.concurrentPerform(iterations: 64) { _ in
+      completion.complete(())
+    }
+
+    XCTAssertEqual(counter.value, 1)
+  }
+
+  func testBackgroundDeliveryEnablementRetriesOnlyLatestFailedAttempt() {
+    let state = BackgroundDeliveryEnablementState()
+    let steps = HKQuantityType.quantityType(forIdentifier: .stepCount)!
+    let observedSampleTypes: Set<HKSampleType> = [steps]
+
+    let firstAttempt = state.beginAttempt(for: steps)
+    XCTAssertTrue(state.record(steps, attemptID: firstAttempt, succeeded: false))
+    XCTAssertEqual(state.failures(intersecting: observedSampleTypes), observedSampleTypes)
+
+    let retryAttempt = state.beginAttempt(for: steps)
+    XCTAssertTrue(state.record(steps, attemptID: retryAttempt, succeeded: true))
+    XCTAssertFalse(state.record(steps, attemptID: firstAttempt, succeeded: false))
+    XCTAssertTrue(state.failures(intersecting: observedSampleTypes).isEmpty)
+  }
+
+  func testBackgroundDeliveryEnablementResetIgnoresLateCallback() {
+    let state = BackgroundDeliveryEnablementState()
+    let steps = HKQuantityType.quantityType(forIdentifier: .stepCount)!
+    let observedSampleTypes: Set<HKSampleType> = [steps]
+    let attempt = state.beginAttempt(for: steps)
+
+    state.reset()
+
+    XCTAssertFalse(state.record(steps, attemptID: attempt, succeeded: false))
+    XCTAssertTrue(state.failures(intersecting: observedSampleTypes).isEmpty)
+  }
+
+  func testTerminatedBackgroundDeliveryStreamCompletesObserverOnce() {
+    let (_, continuation) = AsyncStream<BackgroundDeliveryStage>.makeStream()
+    continuation.finish()
+
+    let counter = LockedCounter()
+    let observerCompletion = OneShotCompletion<Void> { _ in
+      counter.increment()
+    }
+    let payload = BackgroundDeliveryPayload(
+      resources: [],
+      completion: { completion in
+        if completion == .completed {
+          observerCompletion.complete(())
+        }
+      }
+    )
+
+    yieldBackgroundDeliveryPayload(payload, to: continuation)
+    payload.completion(.completed)
+
+    XCTAssertEqual(counter.value, 1)
+  }
+
+  func testExpiredProcessingTaskCannotReportSuccess() {
+    let completed = BackgroundProcessingTaskState()
+    completed.markSucceeded()
+    XCTAssertTrue(completed.shouldCompleteSuccessfully)
+
+    let expired = BackgroundProcessingTaskState()
+    expired.markSucceeded()
+    expired.markExpired()
+    XCTAssertFalse(expired.shouldCompleteSuccessfully)
+  }
+
+  func testProcessingTaskRequestUsesOrdinaryNonChargingPolicy() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let request = makeProcessingTaskRequest(now: now)
+
+    XCTAssertEqual(
+      ObjectIdentifier(type(of: request)),
+      ObjectIdentifier(BGProcessingTaskRequest.self)
+    )
+    XCTAssertEqual(request.identifier, processingTaskIdentifier)
+    XCTAssertFalse(request.requiresExternalPower)
+    XCTAssertTrue(request.requiresNetworkConnectivity)
+    XCTAssertEqual(
+      request.earliestBeginDate,
+      now.addingTimeInterval(processingTaskRetryInterval)
+    )
+  }
+}
+
+private final class LockedCounter: @unchecked Sendable {
+  private let lock = NSLock()
+  private var count = 0
+
+  func increment() {
+    lock.lock()
+    count += 1
+    lock.unlock()
+  }
+
+  var value: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return count
   }
 }


### PR DESCRIPTION
## Summary

- serialize automatic invalid-user sign-out with external-user identification
- retry identification when invalidation begins during an in-flight attempt
- coalesce duplicate automatic sign-out events
- cover both sign-out-first and invalidation-during-identify orderings

## Why

The JWT auth publisher schedules sign-out asynchronously. Without lifecycle ordering, a new identity can be installed before that teardown finishes and then be erased by the delayed sign-out. The coordinator stays private to VitalClient and reuses the existing ParkingLot semaphore.

## Verification

- VitalClientTests on an iOS simulator: 10 passed, 0 failed
- focused concurrency regressions: 2 passed, 0 failed